### PR TITLE
chore: update doco from Private Sphere to www.chrisvogt.me

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ coverage
 launch.json
 node_modules
 public
-www.chrisvogt.me/certs
 yarn-error.log
 www.chrisvogt.me/certs

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ launch.json
 node_modules
 public
 yarn-error.log
+www.chrisvogt.me/certs

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# Chris Vogt, My Personal Website
+# www.chrisvogt.me, My Personal Website
 
 <p align='center'>
+  <a href='https://www.npmjs.org/package/gatsby-theme-chrisvogt'>
+    <img src='https://img.shields.io/npm/v/gatsby-theme-chrisvogt.svg' alt='Current npm package version.' />
+  </a>
   <a href='https://circleci.com/gh/chrisvogt/gatsby-theme-chrisvogt'>
     <img src='https://circleci.com/gh/chrisvogt/gatsby-theme-chrisvogt.svg?style=shield' alt='Current CircleCI build status.' />
   </a>
@@ -15,7 +18,7 @@
   </a>
 </p>
 
-This repository contains my personal website and blog, [www.chrisvogt.me](https://www.chrisvogt.me). The front-end code lives within [the theme directory](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/theme) while the articles live within [the website directory](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/www.chrisvogt.me).
+This repository contains my personal website and blog, [www.chrisvogt.me](https://www.chrisvogt.me). The front-end code lives within [the theme directory](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/theme) and the blog articles live within [the website directory](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/www.chrisvogt.me).
 
 ## Local development
 
@@ -40,6 +43,14 @@ yarn workspace www.chrisvogt.me build
 ```
 
 The website build will be output to `/www.chrisvogt.me/public`.
+
+### How to test the production build
+
+The production build can be run on your local machine over HTTPS if you generate self-signed certificates, which I did using [mkcert](https://github.com/FiloSottile/mkcert). You can use a tool like [http-server](https://www.npmjs.com/package/http-server) to serve the build.
+
+```
+http-server -o -S -C ../certs/www.chrisvogt.me.pem -K ../certs/www.chrisvogt.me-key.pem -a www.chrisvogt.me -p 443
+```
 
 ## Copyright & License
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-<img src='https://raw.githubusercontent.com/chrisvogt/gatsby-theme-chrisvogt/master/theme/assets/hero.png' alt='Theme hero artwork' />
-
-# www.chrisvogt.me – My Personal Website
+# Chris Vogt, My Personal Website
 
 <p align='center'>
-  <a href='https://www.npmjs.org/package/gatsby-theme-chrisvogt'>
-    <img src='https://img.shields.io/npm/v/gatsby-theme-chrisvogt.svg' alt='Current npm package version.' />
-  </a>
   <a href='https://circleci.com/gh/chrisvogt/gatsby-theme-chrisvogt'>
     <img src='https://circleci.com/gh/chrisvogt/gatsby-theme-chrisvogt.svg?style=shield' alt='Current CircleCI build status.' />
   </a>
@@ -20,29 +15,11 @@
   </a>
 </p>
 
-This is the GatsbyJS theme behind my personal website and blog, [www.chrisvogt.me](https://www.chrisvogt.me). My website exists both to display my social network activity in a single place and to share original content on my own platform.
+This repository contains my personal website and blog, [www.chrisvogt.me](https://www.chrisvogt.me). The front-end code lives within [the theme directory](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/theme) while the articles live within [the website directory](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/www.chrisvogt.me).
 
-## Widgets
+## Local development
 
-The following table defines the available widgets.
-
-| Name           | Description                                   | Screenshot                                                                                                                             |
-| -------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Blog Posts     | Recent blog articles                          | ![Widget: Blog Posts](https://raw.githubusercontent.com/chrisvogt/gatsby-theme-chrisvogt/master/theme/assets/widget-blog.png)     |
-| Instagram Feed | Recent Instagram posts                        | ![Widget: Instagram](https://raw.githubusercontent.com/chrisvogt/gatsby-theme-chrisvogt/master/theme/assets/widget-instagram.jpg) |
-| GitHub         | Recent activity, pinned repositories, metrics | ![Widget: GitHub](https://raw.githubusercontent.com/chrisvogt/gatsby-theme-chrisvogt/master/theme/assets/widget-github.png)       |
-| Goodreads      | Recently read books, recent activity, metrics | ![Widget: Goodreads](https://raw.githubusercontent.com/chrisvogt/gatsby-theme-chrisvogt/master/theme/assets/widget-goodreads.png) |
-| Spotify        | Top tracks, metrics                           | ![Widget: Spotify](https://raw.githubusercontent.com/chrisvogt/gatsby-theme-chrisvogt/master/theme/assets/widget-spotify.png)     |
-
-> NOTE: This repository only includes the front-end code. You must supply and connect your own datasources to use the provided widgets. The expected data schema can be found in the [/theme/\_\_mocks\_\_](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/theme/__mocks__) directory.
-
-## To install as a GatsbyJS theme
-
-Find the theme install instructions in [the theme's README](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/theme/README.md).
-
-## To develop the theme on your local machine
-
-This repository is a [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) containing the theme and an example website.
+This repository uses [Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces/) to separate the theme code from the content.
 
 To install, use Yarn. From the root, do:
 
@@ -50,19 +27,19 @@ To install, use Yarn. From the root, do:
 yarn
 ```
 
-To work on the theme, open the `/theme` directory in an editor and run the following command to preview the example website.
+To work on the theme, open the `/theme` directory in an editor and run the following command to preview the website.
 
 ```sh
-yarn workspace example develop
+yarn workspace www.chrisvogt.me develop
 ```
 
-To build the example website, run the following.
+To build the production website, run the following.
 
 ```sh
-yarn workspace example build
+yarn workspace www.chrisvogt.me build
 ```
 
-The example site build will be output to `/example/public`.
+The website build will be output to `/www.chrisvogt.me/public`.
 
 ## Copyright & License
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const chalk = require('chalk')
 
 const package = require('./theme/package.json')
 
-const banner = boxen('www.chrisvogt.me\nMy GatsbyJS Website', {
+const banner = boxen('www.chrisvogt.me\nMy Personal Website', {
   align: 'center',
   backgroundColor: '#9b20dc',
   color: 'white',

--- a/theme/README.md
+++ b/theme/README.md
@@ -20,20 +20,20 @@ yarn add gatsby gatsby-theme-chrisvogt react react-dom
 // gatsby-config.js
 module.exports = {
   siteMetadata: {
-    /* site settings – see /example */
+    /* site settings – see /www.chrisvogt.me */
   },
   plugins: [
     {
       resolve: 'gatsby-theme-chrisvogt',
       options: {
-        /* custom theme options – see /example */
+        /* custom theme options – see /www.chrisvogt.me */
       },
     },
   ],
 }
 ```
 
-Review the [example site configuration](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/example/gatsby-config.js) for an example of available site metadata fields.
+Review the [website site configuration](https://github.com/chrisvogt/gatsby-theme-chrisvogt/tree/master/www.chrisvogt.me/gatsby-config.js) for an example of available site metadata fields.
 
 ## Screenshots
 

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "1.0.0",
+  "version": "0.22.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.21.0",
+  "version": "1.0.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,13 +1,14 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.22.0",
+  "version": "0.21.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",
-  "private": true,
   "bugs": "https://github.com/chrisvogt/gatsby-theme-chrisvogt/issues",
   "keywords": [
+    "personal-website",
+    "gatsby-website",
     "gatsby-plugin",
     "gatsby-theme",
     "gatsby",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12842,9 +12842,9 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     safe-regex "^1.1.0"
 
 regexp.prototype.flags@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.0.tgz#320e3ccb61ebb74daebffd1c09e484ea3c67070b"
-  integrity sha512-OE85RadmCYZJzYgIcWd2Qum/wJ20WwY5Z6Bfv5FeBPU46uPD01s3pe2LNoi0etmr83ibsFidC0ZiKXmPY5UpmQ==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz#b3f4c0059af9e47eca9f3f660e51d81307e72307"
+  integrity sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"


### PR DESCRIPTION
This PR cleans up any documentation still referring to the project as Private Sphere and attempts to make it explicit that this project is my personal website.

I have also removed the [private package](https://docs.npmjs.com/about-private-packages) designation from the theme source code so that I can push it to npm as a public package.

I also add instructions on running the local production build. Doing this recently helped me track down errors with my Redux reducers.