### PR TITLE
fix: touch up theme color modes

### DIFF
--- a/theme/src/components/__snapshots__/home-navigation.spec.js.snap
+++ b/theme/src/components/__snapshots__/home-navigation.spec.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HomeNavigation matches the snapshot 1`] = `
+Array [
+  <h2
+    aria-hidden="true"
+    className="css-6vhbjq-HomeNavigation"
+  >
+    Widget Navigation
+  </h2>,
+  <div
+    className="css-1aj123h-HomeNavigation"
+  >
+    <nav
+      aria-label="Navigate to on-page sections"
+    >
+      <h3
+        className="css-gql1zd-HomeNavigation"
+      >
+        On-page navigation
+      </h3>
+      <a
+        className="css-vurnku"
+        href="#posts"
+      >
+        Latest Posts
+      </a>
+      <a
+        className="css-vurnku"
+        href="#instagram"
+      >
+        Instagram
+      </a>
+      <a
+        className="css-vurnku"
+        href="#github"
+      >
+        GitHub
+      </a>
+      <a
+        className="css-vurnku"
+        href="#goodreads"
+      >
+        Goodreads
+      </a>
+      <a
+        className="css-vurnku"
+        href="#spotify"
+      >
+        Spotify
+      </a>
+    </nav>
+  </div>,
+]
+`;

--- a/theme/src/components/footer/footer.js
+++ b/theme/src/components/footer/footer.js
@@ -13,7 +13,7 @@ export default () => {
 
   return (
     <div sx={{ variant: `styles.PageFooter` }}>
-      <SwoopTop fill='var(--theme-ui-colors-background)' />
+      <SwoopTop />
       <Container sx={{ textAlign: `center` }}>
         <div sx={{ mb: 3, pt: 3, pb: [4, 5] }}>
           <Profiles />

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -28,7 +28,7 @@ const Header = ({ children, hideTopPadding, showSwoop, styles }) => {
       >
         {children}
       </div>
-      {showSwoop && <SwoopBottom fill='var(--theme-ui-colors-background)' />}
+      {showSwoop && <SwoopBottom />}
     </div>
   )
 }

--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -10,7 +10,6 @@ import {
   getInstagramWidgetDataSource,
   getSpotifyWidgetDataSource
 } from '../selectors/metadata'
-import getIsDarkMode from '../helpers/isDarkMode'
 import useSiteMetadata from '../hooks/use-site-metadata'
 
 /**
@@ -130,7 +129,7 @@ const HomeNavigation = () => {
           position: `sticky`,
           top: `1.5em`
         }}
-        variant='infoCard'
+        variant='actionCard'
       >
         <nav aria-label='Navigate to on-page sections' ref={navItemsRef}>
           <h3 sx={{ fontWeight: `unset`, mt: 0, mb: 2 }}>On-page navigation</h3>

--- a/theme/src/components/home-navigation.spec.js
+++ b/theme/src/components/home-navigation.spec.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+
+import HomeNavigation from './home-navigation'
+import useSiteMetadata from '../hooks/use-site-metadata'
+
+jest.mock('../hooks/use-site-metadata')
+
+const mockSiteMetadata = {
+  widgets: {
+    github: {
+      widgetDataSource: 'https://fake-api.chrisvogt.me/social/github'
+    },
+    goodreads: {
+      widgetDataSource: 'https://fake-api.chrisvogt.me/social/goodreads'
+    },
+    instagram: {
+      widgetDataSource: 'https://fake-api.chrisvogt.me/social/instagram'
+    },
+    spotify: {
+      widgetDataSource: 'https://fake-api.chrisvogt.me/social/spotify'
+    }
+  }
+}
+
+describe('HomeNavigation', () => {
+  useSiteMetadata.mockImplementation(() => mockSiteMetadata)
+  it('matches the snapshot', () => {
+    const tree = renderer
+      .create(<HomeNavigation />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/theme/src/components/swoops/get-default-fill-color.js
+++ b/theme/src/components/swoops/get-default-fill-color.js
@@ -1,5 +1,3 @@
-const getDefaultFillColor = ({ colorMode, theme }) => colorMode === 'dark'
-  ? theme.colors.modes.dark.background
-  : theme.colors.background
+const getDefaultFillColor = () => 'var(--theme-ui-colors-background)'
 
 export default getDefaultFillColor

--- a/theme/src/components/swoops/get-default-fill-color.spec.js
+++ b/theme/src/components/swoops/get-default-fill-color.spec.js
@@ -1,32 +1,8 @@
 import getDefaultFillColor from "./get-default-fill-color"
 
-const mockDarkColor = 'mock-dark-background-color'
-const mockLightColor = 'mock-light-background-color'
-
-const themeFixture = {
-  colors: {
-    background: mockLightColor,
-    modes: {
-      dark: {
-        background: mockDarkColor
-      }
-    }
-  }
-}
-
 describe('getDefaultFillColor', () => {
   it('selects the dark theme background color when in dark mode', () => {
-    const result = getDefaultFillColor({
-      colorMode: 'dark',
-      theme: themeFixture
-    })
-    expect(result).toEqual(mockDarkColor)
-  })
-
-  it('defaults to the theme background color', () => {
-    const result = getDefaultFillColor({
-      theme: themeFixture
-    })
-    expect(result).toEqual(mockLightColor)
+    const result = getDefaultFillColor()
+    expect(result).toEqual('var(--theme-ui-colors-background)')
   })
 })

--- a/theme/src/components/swoops/swoop-bottom.js
+++ b/theme/src/components/swoops/swoop-bottom.js
@@ -1,10 +1,9 @@
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx } from 'theme-ui'
 import getDefaultFillColor from './get-default-fill-color'
 
 export default ({ fill }) => {
-  const themeUIContext = useThemeUI()
-  const defaultFillColor = getDefaultFillColor(themeUIContext)
+  const defaultFillColor = getDefaultFillColor()
 
   return (
     <svg

--- a/theme/src/components/swoops/swoop-top.js
+++ b/theme/src/components/swoops/swoop-top.js
@@ -1,10 +1,9 @@
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx } from 'theme-ui'
 import getDefaultFillColor from './get-default-fill-color'
 
 export default ({ fill }) => {
-  const themeUIContext = useThemeUI()
-  const defaultFillColor = getDefaultFillColor(themeUIContext)
+  const defaultFillColor = getDefaultFillColor()
 
   return (
     <svg

--- a/theme/src/components/widgets/github/last-pull-request.js
+++ b/theme/src/components/widgets/github/last-pull-request.js
@@ -1,11 +1,9 @@
 /** @jsx jsx */
-import { jsx, Themed, useThemeUI } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 import { Box, Card, Heading } from '@theme-ui/components'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
 import PropTypes from 'prop-types'
-
-import isDarkMode from '../../../helpers/isDarkMode'
 
 import CardFooter from '../card-footer'
 import ViewExternal from '../view-external'
@@ -17,9 +15,6 @@ const LastPullRequest = ({ isLoading, pullRequest }) => {
     title,
     url
   } = pullRequest
-
-  const { colorMode } = useThemeUI()
-  const variant = isDarkMode(colorMode) ? 'actionCardDark' : 'actionCard'
 
   return (
     <Box>
@@ -41,7 +36,7 @@ const LastPullRequest = ({ isLoading, pullRequest }) => {
           }
         }}
       >
-        <Card variant={variant}>
+        <Card variant='actionCard'>
           <Placeholder
             color='#efefef'
             customPlaceholder={

--- a/theme/src/components/widgets/github/pinned-item-card.js
+++ b/theme/src/components/widgets/github/pinned-item-card.js
@@ -1,10 +1,8 @@
 /** @jsx jsx */
-import { jsx, useThemeUI } from 'theme-ui'
+import { jsx } from 'theme-ui'
 import { Card } from '@theme-ui/components'
 
 import PropTypes from 'prop-types'
-
-import isDarkMode from '../../../helpers/isDarkMode'
 
 import PlaceholderContent from './renderers/placeholder'
 import RepositoryContent from './renderers/repository'
@@ -18,11 +16,8 @@ const rendererRegistry = {
 }
 
 const PinnedItemCard = ({ item, type }) => {
-  const { colorMode } = useThemeUI()
-  const variant = isDarkMode(colorMode) ? 'actionCardDark' : 'actionCard'
-
   return (
-    <Card variant={variant}>
+    <Card variant='actionCard'>
       {rendererRegistry[type] && rendererRegistry[type](item)}
     </Card>
   )

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -1,12 +1,11 @@
 /** @jsx jsx */
-import { jsx, Themed, useThemeUI } from 'theme-ui'
+import { jsx, Themed } from 'theme-ui'
 import { Box, Card, Heading } from '@theme-ui/components'
 import ago from 's-ago'
 import PropTypes from 'prop-types'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
 
-import isDarkMode from '../../../helpers/isDarkMode'
 import CardFooter from '../card-footer'
 import ViewExternal from '../view-external'
 
@@ -33,9 +32,6 @@ const UserStatus = ({ isLoading, status, actorName }) => {
     ? mapStatusToTemplate[type](status)
     : 'Loading...'
 
-  const { colorMode } = useThemeUI()
-  const variant = isDarkMode(colorMode) ? 'actionCardDark' : 'actionCard'
-
   return (
     <Box>
       <Heading
@@ -56,7 +52,7 @@ const UserStatus = ({ isLoading, status, actorName }) => {
           }
         }}
       >
-        <Card variant={variant}>
+        <Card variant='actionCard'>
           <Placeholder
             color='#efefef'
             customPlaceholder={

--- a/theme/src/components/widgets/metric-card.js
+++ b/theme/src/components/widgets/metric-card.js
@@ -15,7 +15,7 @@ import Placeholder from 'react-placeholder'
  */
 const MetricCard = ({ title, value, showPlaceholder }) => {
   const { colorMode } = useThemeUI()
-  const variant = isDarkMode(colorMode) ? 'infoCardDark' : 'infoCard'
+  const variant = isDarkMode(colorMode) ? 'metricCardDark' : 'metricCard'
 
   return (
     <Card variant={variant}>

--- a/theme/src/components/widgets/status-card.js
+++ b/theme/src/components/widgets/status-card.js
@@ -7,7 +7,7 @@ import isDarkMode from '../../helpers/isDarkMode'
 
 const StatusCard = ({ message }) => {
   const { colorMode } = useThemeUI()
-  const variant = isDarkMode(colorMode) ? 'infoCardDark' : 'infoCard'
+  const variant = isDarkMode(colorMode) ? 'metricCardDark' : 'metricCard'
 
   return (
     <Card variant={variant} sx={{ mb: 3 }}>

--- a/theme/src/gatsby-plugin-theme-ui/components/card.js
+++ b/theme/src/gatsby-plugin-theme-ui/components/card.js
@@ -1,16 +1,16 @@
 import { floatOnHover } from '../abstracts/shadows'
 
 export const card = {
-  backgroundColor: `white`,
+  backgroundColor: `var(--theme-ui-colors-panel-background)`,
+  color: 'var(--theme-ui-colors-panel-text)',
   borderRadius: `3px`,
   boxShadow: `default`,
-  color: `text`,
   flexGrow: 1,
   padding: 3,
   textDecoration: `none`
 }
 
-export const infoCard = {
+export const metricCard = {
   backgroundColor: `var(--theme-ui-colors-panel-background)`,
   boxShadow: `none`,
   color: 'var(--theme-ui-colors-panel-text)',

--- a/theme/src/gatsby-plugin-theme-ui/index.js
+++ b/theme/src/gatsby-plugin-theme-ui/index.js
@@ -1,7 +1,7 @@
 import colors from './abstracts/colors'
 import fonts from './abstracts/fonts'
 
-import { card, infoCard, PostCard } from './components/card'
+import { card, metricCard, PostCard } from './components/card'
 
 import { floatOnHover } from './abstracts/shadows'
 
@@ -33,21 +33,13 @@ export default merge(themePreset, {
     actionCard: {
       ...card,
       ...floatOnHover,
+      borderBottom: `none`, // from actionCardDark
       borderLeft: theme => `3px solid ${theme.colors.primary}`
     },
 
-    actionCardDark: {
+    metricCard: {
       ...card,
-      ...floatOnHover,
-      backgroundColor: `#252e3c`,
-      borderBottom: `none`,
-      borderLeft: theme => `3px solid ${theme.colors.primary}`,
-      color: `white`
-    },
-
-    infoCard: {
-      ...card,
-      ...infoCard
+      ...metricCard
     },
 
     /* The following styles represent specific card components, indicated in PascalCase. */


### PR DESCRIPTION
This PR builds on recent work attempting to stabilize the color mode on first render by factoring out JS toggling between color modes and switching to make more use of CSS vars.