### PR TITLE
feat: vertically align widget CTA and headline

### DIFF
--- a/theme/src/components/widgets/__snapshots__/call-to-action.spec.js.snap
+++ b/theme/src/components/widgets/__snapshots__/call-to-action.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CallToAction matches the snapshot 1`] = `
 <a
-  className="css-104kj7r-CallToAction"
+  className="css-1h8xfji-CallToAction"
   title="Example Widget Title"
 >
   Test

--- a/theme/src/components/widgets/call-to-action.js
+++ b/theme/src/components/widgets/call-to-action.js
@@ -30,6 +30,8 @@ const CallToAction = ({ children, isLoading, title, to, url }) => {
       sx={{
         fontSize: 0,
         fontFamily: 'heading',
+        lineHeight: '1.25', // synced with widget header
+        verticalAlign: 'bottom',
         '.read-more-icon': {
           opacity: 0,
           transition: `all .3s ease`


### PR DESCRIPTION
This PR improves the vertical alignment of the widget `<CallToAction />` component so that it aligns on the bottom with the widget headline.

### Before

<img width="399" alt="before" src="https://user-images.githubusercontent.com/1934719/182036592-d5202ab0-9149-4e6f-9d99-04c41aa0bc3d.png">

### After

<img width="399" alt="after" src="https://user-images.githubusercontent.com/1934719/182036603-6ee3e431-eea2-48d4-9664-5922b935c02b.png">
