### PR TITLE
chore: adds a Lighthouse score audit via GitHub Actions

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,14 +6,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - name: Install & Build
-        run: |
-          yarn install
-          yarn build
       - name: Wait for the Netlify Preview
         uses: jakepartusch/wait-for-netlify-action@v1
         id: netlify

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,24 +1,29 @@
-name: Lighthouse Scores
-
-on:
-  push:
-    branches: ["master"]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: ["master"]
-
+name: Lighthouse CI for Netlify sites
+on: pull_request
 jobs:
-  audit:
-    name: Lighthouse audit
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Audit deploy preview
-        uses: jakejarvis/lighthouse-action@master
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
         with:
-          netlify_site: chrisvogt
-      - name: Upload results as an artifact
-        uses: actions/upload-artifact@master
+          node-version: 12.x
+      - name: Install & Build
+        run: |
+          yarn install
+          yarn build
+      - name: Wait for the Netlify Preview
+        uses: jakepartusch/wait-for-netlify-action@v1
+        id: netlify
         with:
-          name: report
-          path: "./report"
+          site_name: 'chrisvogt'
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v9
+        with:
+          urls: |
+            ${{ steps.netlify.outputs.url }}
+            ${{ steps.netlify.outputs.url }}/latest
+            ${{ steps.netlify.outputs.url }}/meta/hello-world
+          uploadArtifacts: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,10 +6,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 17.x
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: 17.x
+          node-version: 14.x
       - name: Install & Build
         run: |
           yarn install

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,6 +6,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
       - name: Wait for the Netlify Preview
         uses: jakepartusch/wait-for-netlify-action@v1
         id: netlify
@@ -16,6 +20,5 @@ jobs:
         with:
           urls: |
             ${{ steps.netlify.outputs.url }}
-            ${{ steps.netlify.outputs.url }}/latest
-            ${{ steps.netlify.outputs.url }}/meta/hello-world
-          uploadArtifacts: true
+          uploadArtifacts: true # save results as an action artifacts
+          temporaryPublicStorage: true # upload lighthouse report to the temporary storage

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -6,10 +6,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
+      - name: Use Node.js 17.x
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 17.x
       - name: Install & Build
         run: |
           yarn install

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,24 @@
+name: Lighthouse Scores
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: ["master"]
+
+jobs:
+  audit:
+    name: Lighthouse audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Audit deploy preview
+        uses: jakejarvis/lighthouse-action@master
+        with:
+          netlify_site: chrisvogt
+      - name: Upload results as an artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: report
+          path: "./report"


### PR DESCRIPTION
This PR uses [`treosh/lighthouse-ci-action`](https://github.com/treosh/lighthouse-ci-action) to connect a Lighthouse score audit to PRs going forward.