### PR TITLE
fix(styles): correct card styles defaulting to link colors

### DIFF
--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -14,9 +14,9 @@ import useSiteMetadata from '../hooks/use-site-metadata'
 
 /**
  * Link Registry
- * 
+ *
  * The items in this array follow the following schema:
- * 
+ *
  * * rule {function} – validator function
  * * value {object} – props for the link item
  */
@@ -71,7 +71,7 @@ const determineLinksToRender = (options = {}) => {
     return linksToRender
   }, [])
 
-  return links;
+  return links
 }
 
 const HomeNavigation = () => {
@@ -134,7 +134,12 @@ const HomeNavigation = () => {
         <nav aria-label='Navigate to on-page sections' ref={navItemsRef}>
           <h3 sx={{ fontWeight: `unset`, mt: 0, mb: 2 }}>On-page navigation</h3>
           {links.map(({ href, id, text }) => (
-            <Link href={href} key={id} variant='homeNavigation'>
+            <Link
+              href={href}
+              key={id}
+              variant='homeNavigation'
+              sx={{ color: `var(--theme-ui-colors-panel-text)` }}
+            >
               {text}
             </Link>
           ))}

--- a/theme/src/components/widgets/github/last-pull-request.js
+++ b/theme/src/components/widgets/github/last-pull-request.js
@@ -30,6 +30,7 @@ const LastPullRequest = ({ isLoading, pullRequest }) => {
       <Themed.a
         href={url}
         sx={{
+          color: `var(--theme-ui-colors-panel-text)`,
           display: `flex`,
           '&:hover, &:focus': {
             textDecoration: `none`

--- a/theme/src/components/widgets/github/pinned-items.js
+++ b/theme/src/components/widgets/github/pinned-items.js
@@ -38,6 +38,7 @@ const PinnedItems = ({ isLoading, items = [], placeholderCount = 4 }) => {
             href={item.url}
             key={item.id || index}
             sx={{
+              color: `var(--theme-ui-colors-panel-text)`,
               display: `flex`,
               '&:hover, &:focus': {
                 textDecoration: `none`

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -46,6 +46,7 @@ const UserStatus = ({ isLoading, status, actorName }) => {
       <Themed.a
         href={link}
         sx={{
+          color: `var(--theme-ui-colors-panel-text)`,
           display: `flex`,
           '&:hover, &:focus': {
             textDecoration: `none`


### PR DESCRIPTION
This PR fixes colors rendered in some of the home page widget cards.

| Title  |  Before | 2a9f59b  |
|---|---|---|
| Goodreads  |  <img width="1655" alt="before-goodreads" src="https://user-images.githubusercontent.com/1934719/182821075-9fb4ad85-ea37-42bf-b74e-efe349217160.png"> |  <img width="1655" alt="after-goodreads" src="https://user-images.githubusercontent.com/1934719/182821061-abf6565b-a12d-436e-94d4-ba8b80f3ab73.png"> |
| GitHub | <img width="1655" alt="before-github" src="https://user-images.githubusercontent.com/1934719/182821084-8f6ca5e5-b30d-4f56-9d9c-f129b57f5e20.png"> |  <img width="1655" alt="after-github" src="https://user-images.githubusercontent.com/1934719/182821080-8326f40a-56f4-43b0-a96d-154d58667411.png"> |
