### PR TITLE
feat: lazy load home page social images

### DIFF
--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -11,6 +11,7 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
     className="instagram-item-image css-ko57dg-InstagramWidgetItem"
     crossOrigin="anonymous"
     height="280"
+    loading="lazy"
     src="undefined?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format"
     width="280"
   />

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -38,6 +38,7 @@ const InstagramWidgetItem = ({
       <img
         crossOrigin='anonymous'
         className='instagram-item-image'
+        loading='lazy'
         src={`${cdnMediaURL}?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format`}
         height='280'
         width='280'

--- a/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
@@ -38,6 +38,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b273275083a05d58f2f6708c93f4ab67616d0000b27383df44cde2ecfd41bfa9d03bab67616d0000b2738f570fac0016076d60777e96ab67616d0000b273f1ae9c707f6ec5e80e5fe169"
         />
       </a>
@@ -61,6 +62,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b2730bc295fb742c44064e6abccbab67616d0000b2732ba46acbe49b6d40d5439b34ab67616d0000b273bf20d7182e5552c97861a5f4ab67616d0000b273cacd7b87c756da21745e516a"
         />
       </a>
@@ -84,6 +86,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b273795b4776348911921d7b34caab67616d0000b273b2adf664bf57ab1070e642bcab67616d0000b273bd9665c874c92ae24a54164aab67616d0000b273e14f11f796cef9f9a82691a7"
         />
       </a>
@@ -107,6 +110,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b2732399c0aa5d07a56921cbae9bab67616d0000b2733960505e249b30cac0ce8d82ab67616d0000b27357c375e481922937e31de2c0ab67616d0000b2739d6bd2afa2987a69b7b55f72"
         />
       </a>
@@ -130,6 +134,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b27343c3e9ed6a415659601e3463ab67616d0000b2734e851f5899d7b7c0dd95f9efab67616d0000b2736a4ba4bf22f0c73d0ad24a99ab67616d0000b273b746f162c97d38e8d04d9ead"
         />
       </a>
@@ -153,6 +158,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b2730786798fac9a15f293a62502ab67616d0000b2733b83944662e1c181c2056307ab67616d0000b2735406f784d9a47154dadf8cb7ab67616d0000b273d0927ea5b0dde802e65eb9b6"
         />
       </a>
@@ -176,6 +182,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b2735f40be7506754451d1e61e16ab67616d0000b273930f6a7ee143629902a43c4bab67616d0000b2739b08d40d40c8dce75e644604ab67616d0000b273c13acd642ba9f6f5f127aa1b"
         />
       </a>
@@ -199,6 +206,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b27342076f3afa79624ace2cb9d4ab67616d0000b273c1d7ffae3923f6a965867a10ab67616d0000b273dafd1cd6e9537ec8463ea691ab67616d0000b273ef9c24b433c960deb46ec41f"
         />
       </a>
@@ -222,6 +230,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b27332d6a86ca998e8dba61d0425ab67616d0000b273709c46f2bfe30708aa50f7f2ab67616d0000b27391202d94438fb64ffbb95bfdab67616d0000b273a045e78db2ea4a1e80f4975b"
         />
       </a>
@@ -245,6 +254,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b2733b756f5e4dd42e7d8026a3bbab67616d0000b273531b76efe8a8532da014339eab67616d0000b2737dd8f95320e8ef08aa121dfeab67616d0000b273fba6de0b38b0168d480b1a27"
         />
       </a>
@@ -268,6 +278,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://lineup-images.scdn.co/wrapped-2020-top100_LARGE-en.jpg"
         />
       </a>
@@ -291,6 +302,7 @@ exports[`Playlists matches the snapshot 1`] = `
           alt="cover artwork"
           className="css-1k47td7-MediaItemGrid"
           crossOrigin="anonymous"
+          loading="lazy"
           src="https://mosaic.scdn.co/300/ab67616d0000b2730dc777f04e02631c126e16e0ab67616d0000b2732759da8db912a1a5a2aad253ab67616d0000b2732a02859369c5741d21f1a28aab67616d0000b273c541f3de06805ce54ec02362"
         />
       </a>

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -58,6 +58,7 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
                   <img
                     alt='cover artwork'
                     crossOrigin='anonymous'
+                    loading='lazy'
                     src={thumbnailURL}
                     sx={{
                       ...floatOnHover,


### PR DESCRIPTION
This PR enables [browser-level image lazy-loading](https://web.dev/browser-level-image-lazy-loading/) for all images below the blog posts widget on the home page.

## Demonstration

The following screenshots compare image requests for www.chrisvogt.me without lazy loading enabled vs the local development server with lazy loading enabled.

 | Before | 26079bf |
|---|---|
| <img width="1503" alt="before" src="https://user-images.githubusercontent.com/1934719/183258974-8a37cbf5-19dd-45ac-bf5e-8f1f497069ac.png"> | <img width="1503" alt="after" src="https://user-images.githubusercontent.com/1934719/183258978-a46feed2-43be-4fc9-af3b-511dde1baee2.png"> |
