### PR TITLE
fix: remove duplicate title from article

### DIFF
--- a/www.chrisvogt.me/content/music/2020-09-08-nights-in-white-satin.mdx
+++ b/www.chrisvogt.me/content/music/2020-09-08-nights-in-white-satin.mdx
@@ -13,8 +13,6 @@ type: media
 soundcloudId: 880888540
 ---
 
-# Nights In White Satin (Piano Cover) – The Moody Blues
-
 Hey everyone,
 
 I'm excited to share another piano practice session with you. Lately, I've been drawn to the timeless melodies of the 60s and 70s, and I've been exploring learning these classic songs on the piano. Today, I'm sharing a recording of me playing "Nights In White Satin" by The Moody Blues on the piano.


### PR DESCRIPTION
Removes an H1 page title I accidentally included in updated page content.