### PR TITLE
feat: global smooth scroll via CSS instead of JS in one nav component

### DIFF
--- a/theme/src/components/__snapshots__/home-navigation.spec.js.snap
+++ b/theme/src/components/__snapshots__/home-navigation.spec.js.snap
@@ -16,6 +16,33 @@ exports[`HomeNavigation matches the snapshot 1`] = `
     >
       <a
         className="css-1v4indd-Box"
+        href="#top"
+      >
+        <svg
+          aria-hidden="true"
+          className="svg-inline--fa fa-house css-1goj2uy"
+          data-icon="house"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          style={
+            {
+              "height": "18px",
+            }
+          }
+          viewBox="0 0 576 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M575.8 255.5c0 18-15 32.1-32 32.1h-32l.7 160.2c0 2.7-.2 5.4-.5 8.1V472c0 22.1-17.9 40-40 40H456c-1.1 0-2.2 0-3.3-.1c-1.4 .1-2.8 .1-4.2 .1H416 392c-22.1 0-40-17.9-40-40V448 384c0-17.7-14.3-32-32-32H256c-17.7 0-32 14.3-32 32v64 24c0 22.1-17.9 40-40 40H160 128.1c-1.5 0-3-.1-4.5-.2c-1.2 .1-2.4 .2-3.6 .2H104c-22.1 0-40-17.9-40-40V360c0-.9 0-1.9 .1-2.8V287.6H32c-18 0-32-14-32-32.1c0-9 3-17 10-24L266.4 8c7-7 15-8 22-8s15 2 21 7L564.8 231.5c8 7 12 15 11 24z"
+            fill="currentColor"
+            style={{}}
+          />
+        </svg>
+        Home
+      </a>
+      <a
+        className="css-1v4indd-Box"
         href="#posts"
       >
         <svg

--- a/theme/src/components/home-navigation.js
+++ b/theme/src/components/home-navigation.js
@@ -1,9 +1,8 @@
 /** @jsx jsx */
 import { Fragment } from 'react'
 import { Heading, jsx, Link } from 'theme-ui'
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { Card } from '@theme-ui/components'
-import { Themed } from '@theme-ui/mdx'
 
 import {
   getGithubWidgetDataSource,
@@ -13,7 +12,7 @@ import {
 } from '../selectors/metadata'
 import useSiteMetadata from '../hooks/use-site-metadata'
 
-import { faNewspaper } from '@fortawesome/free-solid-svg-icons'
+import { faHome, faNewspaper } from '@fortawesome/free-solid-svg-icons'
 import { faGithub, faGoodreads, faSpotify, faInstagram } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
@@ -25,6 +24,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 const icons = {
   faGithub,
   faGoodreads,
+  faHome,
   faInstagram,
   faNewspaper,
   faSpotify
@@ -39,6 +39,18 @@ const icons = {
  * * value {object} – props for the link item
  */
 const linkRegistry = [
+  {
+    rule: () => true, // Everyone sees this.
+    value: {
+      href: '#top',
+      icon: {
+        name: 'home',
+        reactIcon: 'faHome'
+      },
+      id: 'home',
+      text: 'Home'
+    }
+  },
   {
     rule: () => true, // Everyone sees this.
     value: {
@@ -122,28 +134,6 @@ const HomeNavigation = () => {
     isInstagramWidgetEnabled: getInstagramWidgetDataSource(metadata),
     isSpotifyWidgetEnabled: getSpotifyWidgetDataSource(metadata)
   })
-
-  useEffect(() => {
-    const navItemsEl = navItemsRef.current
-
-    const handleSmoothScroll = event => {
-      const el = event.target || event.srcElement
-      if (el instanceof HTMLAnchorElement) {
-        event.preventDefault()
-
-        const href = el.getAttribute('href')
-        document.querySelector(href).scrollIntoView({
-          behavior: 'smooth'
-        })
-      }
-    }
-
-    navItemsEl.addEventListener('click', handleSmoothScroll)
-
-    return () => {
-      navItemsEl.removeEventListener('click', handleSmoothScroll)
-    }
-  }, [])
 
   return (
     <Fragment>

--- a/theme/src/styles/global.css
+++ b/theme/src/styles/global.css
@@ -1,5 +1,10 @@
 html {
   min-height: 100%;
+  scroll-behavior: smooth;
+
+  @media (prefers-reduced-motion) {
+    scroll-behavior: unset;
+  }
 }
 
 body,


### PR DESCRIPTION
This PR factors out custom event handlers and a smooth scroll behavior that targeted only the on-page Home navigation links.

Instead of hijacking the click events for those links and using JavaScript to apply the smooth scroll behavior, I'm using CSS to apply that behavior to every page's **html** element. If this turns out to be too much we can narrow the scope down to specific pages and/or elements.

I'm also adding a new home page left navigation menu item "Home" that uses the anchor element **#top** to navigate users back to the top of the page.