### PR TITLE
fix: space sometimes visible below header swoop

### DIFF
--- a/theme/src/components/__snapshots__/header.spec.js.snap
+++ b/theme/src/components/__snapshots__/header.spec.js.snap
@@ -10,7 +10,8 @@ exports[`Header matches the snapshot 1`] = `
     Wow!
   </div>
   <svg
-    className="css-1l6n94m"
+    className="css-odb3nj"
+    height="auto"
     preserveAspectRatio="xMidYMin slice"
     viewBox="0 0 1366 63"
     width="100%"

--- a/theme/src/components/swoops/__snapshots__/swoop-bottom.spec.js.snap
+++ b/theme/src/components/swoops/__snapshots__/swoop-bottom.spec.js.snap
@@ -2,7 +2,8 @@
 
 exports[`SwoopBottom matches the snapshot 1`] = `
 <svg
-  className="css-1l6n94m"
+  className="css-odb3nj"
+  height="auto"
   preserveAspectRatio="xMidYMin slice"
   viewBox="0 0 1366 63"
   width="100%"

--- a/theme/src/components/swoops/swoop-bottom.js
+++ b/theme/src/components/swoops/swoop-bottom.js
@@ -11,9 +11,13 @@ export default ({ fill }) => {
       preserveAspectRatio='xMidYMin slice'
       xmlns='http://www.w3.org/2000/svg'
       viewBox='0 0 1366 63'
+      height='auto'
       sx={{
         fill: fill || defaultFillColor,
-        verticalAlign: 'bottom'
+        verticalAlign: 'bottom',
+        // Hack to fix a bug in some browser where a fraction of a pixel
+        // of space is sometimes rendered below the swoop
+        marginBottom: '-1px'
       }}
     >
       <path


### PR DESCRIPTION
This PR fixes a bug sometimes visible below the white accent swoop in the header. It's visible in Safari on smaller screen sizes.

<img width="758" alt="Screenshot 2024-06-02 at 5 36 46 PM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/453b3234-e24b-4f0b-928f-601e48ff6778">
