### PR TITLE
chore: optimize images and address a11y warnings

### DIFF
--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -25,11 +25,11 @@ exports[`PostCard matches the snapshot 1`] = `
       >
         personal
       </span>
-      <h4
+      <h3
         className="css-13imqch"
       >
         My Blog Post
-      </h4>
+      </h3>
       <time
         className="created css-1c6hy0j"
       >

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -38,7 +38,7 @@ export default ({ banner, category, date, link, title }) => {
 
           {category && <span sx={{ variant: `text.title`, mt: 1, fontSize: [1] }}>{category}</span>}
 
-          <Themed.h4 sx={{ mt: 2, fontFamily: 'serif' }}>{title}</Themed.h4>
+          <Themed.h3 sx={{ mt: 2, fontFamily: 'serif' }}>{title}</Themed.h3>
 
           <time
             className='created'

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -182,11 +182,12 @@ export default merge(tailwind, {
         'panel-background': `#252e3c`,
         'panel-divider': theme => `1px solid ${theme.colors.gray[8]}`,
         'panel-highlight': theme => theme.colors.gray[8],
+        primary: `#1E90FF`,
         text: `#e2e8f0`,
         textMuted: '#a0aec0'
       }
     },
-    primary: `#1E90FF`,
+    primary: `#0073E6`,
     secondary: `#711E9B`,
     secondaryGradient: `linear-gradient(45deg, #4527a0 0%, #711e9b 100%)`,
     text: `#2d3748`

--- a/www.chrisvogt.me/content/music/2024-05-12-a-house-is-not-a-home.mdx
+++ b/www.chrisvogt.me/content/music/2024-05-12-a-house-is-not-a-home.mdx
@@ -1,6 +1,6 @@
 ---
-banner: https://res.cloudinary.com/chrisvogt/image/upload/v1717282723/piano-practice-banner_ydb1ei.jpg
-title: A House is Not A Home - Piano Practice Session
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1717282723/piano-practice-banner_ydb1ei.jpg
+title: A House Is Not A Home - Piano Practice Session
 date: '2024-05-12T21:00:01.100Z'
 category: music
 slug: 2024-a-house-is-not-a-home


### PR DESCRIPTION
This PR addresses warnings in my Google Lighthouse report, and updates the latest post artwork to use a modern web format (webp).

<img width="1773" alt="Screenshot 2024-06-02 at 7 23 14 PM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/293fee24-92fc-458f-b63b-da80baf4dce0">
