### PR TITLE
fix: codeql-analysis.yml to use main branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: ['master']
+    branches: ['main']
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: ['master']
+    branches: ['main']
   schedule:
     - cron: '37 14 * * 2'
 


### PR DESCRIPTION
This PR reconnects the CodeQL GitHub Action by updating it to recognize the `main` branch.