### PR TITLE
fix: a11y warnings stemming from the color mode toggle dependency

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -93,7 +93,7 @@
     "prismjs": "^1.24.1",
     "prop-types": "^15.7.2",
     "react": "^18",
-    "react-dark-mode-toggle-2": "^2.0.9",
+    "react-dark-mode-toggle-2": "github:chrisvogt/react-dark-mode-toggle-2#button-attributes-build",
     "react-dom": "^18",
     "react-images": "^1.2.0-beta.7",
     "react-photo-gallery": "^8.0.0",

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/top-navigation.spec.js.snap
+++ b/theme/src/components/__snapshots__/top-navigation.spec.js.snap
@@ -31,9 +31,9 @@ exports[`TopNavigation matches the snapshot 1`] = `
       </a>
     </div>
     <button
-      aria-hidden="true"
+      aria-label="Set color mode to light"
       className="_button_2eo6g_1"
-      id=""
+      id="color-mode-toggle"
       onClick={[Function]}
       style={
         {

--- a/theme/src/components/color-toggle.js
+++ b/theme/src/components/color-toggle.js
@@ -8,6 +8,10 @@ export default () => {
 
   return (
     <DarkModeToggle
+      id='color-mode-toggle'
+      attributes={{
+        'aria-label': `Set color mode to ${colorMode === 'default' ? 'dark' : 'light'}`
+      }}
       onChange={() => setColorMode(colorMode === 'default' ? 'dark' : 'default')}
       isDarkMode={isDarkMode(colorMode)}
       checked={colorMode === 'dark'}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11720,10 +11720,9 @@ react-clientside-effect@^1.2.6:
   dependencies:
     "@babel/runtime" "^7.12.13"
 
-react-dark-mode-toggle-2@^2.0.9:
-  version "2.0.9"
-  resolved "https://registry.yarnpkg.com/react-dark-mode-toggle-2/-/react-dark-mode-toggle-2-2.0.9.tgz#f6ae6b0d957fbd361a4cf00c548ef48e46c0b8e4"
-  integrity sha512-bW++7scae/03CYEawI4RW9aeikNWadJ9vwZTa9i6dbiloJnLPRxAsg8BH9zbtVf4SbalqPHoRycKw2rO1KHPig==
+"react-dark-mode-toggle-2@github:chrisvogt/react-dark-mode-toggle-2#button-attributes-build":
+  version "2.1.0"
+  resolved "https://codeload.github.com/chrisvogt/react-dark-mode-toggle-2/tar.gz/ae739e13a9ff8cd1f69cfef731b185153b6cd501"
   dependencies:
     classnames "^2.3.2"
     react-lottie-player "^1.4.3"


### PR DESCRIPTION
Using Google Lighthouse and the [WAVE Web Accessibility Evaluation Tools](https://wave.webaim.org/) I found the following issues coming from the animated color mode toggle I'm using, [todd-elvers/react-dark-mode-toggle-2](https://github.com/todd-elvers/react-dark-mode-toggle-2).

1. `aria-hidden` is forced to false for an interactive element, hiding it from screen readers
2. There is no label for the button.

These two items make the button inaccessible to customers relying on the assistance of screen readers. People rely on assistive technology for a range of reasons. They may have partial sight or a specific colorblindness. Even with a preferred color mode set, they may still prefer or need to use one or the other color modes.

Because of the reasons above, and because [we shouldn't use `aria-hidden` on focusable elements](https://dequeuniversity.com/rules/axe/4.0/aria-hidden-focus), I've updated the color toggle to add `aria-label` and remove the hidden attribute.

## How I implemented this change

I plan to reach out to @todd-elvers and the people who maintain todd-elvers/react-dark-mode-toggle-2 and contribute a fix. I have a branch stashed at chrisvogt/react-dark-mode-toggle-2@094fc96a8c7cdcf63cba56722b1031141a219de5, which removes the hidden label and accepts a new optional prop called `attributes`, which are spread onto the button element.

The package owners may have other preferred ways to achieve this, but using `attributes` should allow me to pass in other useful fields in the future – other aria attributes, or data-* attributes, like data-testid.

Until that's fixed in the main package, I've created a branch with the build checked into it, and I've manually installed that in my package.json to use my fork.

## Screenshots

### Lighthouse score before

Before this change my Lighthouse score was 89, and errors were being thrown because `aria-hidden` was set on a focusable element.

<img width="488" alt="Screenshot 2024-06-09 at 12 46 14 AM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/152c06b7-74d6-4c8e-8aa2-9d2a665a3a9f">

WAVE also warned that the button had no identifiable name.

<img width="1548" alt="Screenshot 2024-06-09 at 12 45 32 AM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/72e42aef-8464-4557-857a-d97bdd54e717">

### Lighthouse score after

<img width="370" alt="Screenshot 2024-06-09 at 12 57 45 AM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/30217537-0dda-45a6-9673-61e2b1dd061f">

