### PR TITLE
fix: the RSS feed post URLs

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/plugins/gatsby-plugin-feed.config.js
+++ b/www.chrisvogt.me/plugins/gatsby-plugin-feed.config.js
@@ -1,3 +1,8 @@
+const buildFeedItemUrl = (baseUrl, category, slug) => {
+  const parsedCategory = category ? `/${category}/` : `/`;
+  return `${baseUrl}${parsedCategory}${slug}`
+}
+
 module.exports = {
   resolve: `gatsby-plugin-feed`,
   options: {
@@ -24,7 +29,7 @@ module.exports = {
               feed_url: site.siteMetadata.baseUrl + '/rss.xml',
               guid: site.siteMetadata.baseURL + edge.node.fields.slug,
               ...(hasImage ? { image: edge.node.frontmatter.banner } : {}),
-              url: site.siteMetadata.baseURL + edge.node.fields.slug
+              url: buildFeedItemUrl(site.siteMetadata.baseURL, edge.node.fields.category, edge.node.fields.slug)
             })
           })
         },


### PR DESCRIPTION
This PR resolves #185 by updating the RSS feed's post URLs to include the category. I've verified using the deploy preview link below and the issue is resolved by these changes. 🚀 

<img width="1664" alt="Screenshot 2024-06-17 at 7 47 01 PM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/53b2084a-744a-43e3-aea7-1c2a883ed405">

<img width="1664" alt="Screenshot 2024-06-17 at 7 46 58 PM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/b0037c1a-19ce-4071-bda5-4ddaf914132d">