### PR TITLE
feat: add a Show More button for Instagram posts

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/button.js
+++ b/theme/src/components/button.js
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+
+const Button = ({ variant = 'primary', ...props }) => (
+  <button
+    {...props}
+    sx={{
+      appearance: 'none',
+      display: 'inline-block',
+      textAlign: 'center',
+      lineHeight: 'inherit',
+      textDecoration: 'none',
+      fontSize: 'inherit',
+      fontWeight: 'bold',
+      m: 0,
+      px: 3,
+      py: 2,
+      border: 0,
+      borderRadius: 4,
+      // pass variant prop to sx
+      variant: `buttons.${variant}`
+    }}
+  />
+)
+
+export default Button

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -1,11 +1,13 @@
 /** @jsx jsx */
-import { Grid } from '@theme-ui/components'
 import { jsx } from 'theme-ui'
+
+import { Grid } from '@theme-ui/components'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useCallback, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffect } from 'react'
 import Carousel, { Modal, ModalGateway } from 'react-images'
+import { Flex } from '@theme-ui/components'
 import { faInstagram } from '@fortawesome/free-brands-svg-icons'
 import ReactPlaceholder from 'react-placeholder'
 
@@ -14,13 +16,17 @@ import { getInstagramUsername, getInstagramWidgetDataSource } from '../../../sel
 import { SUCCESS, FAILURE, getInstagramWidget } from '../../../reducers/widgets'
 import useSiteMetadata from '../../../hooks/use-site-metadata'
 
+import Button from '../../button'
 import CallToAction from '../call-to-action'
 import ProfileMetricsBadge from '../profile-metrics-badge'
 import Widget from '../widget'
 import WidgetHeader from '../widget-header'
 import WidgetItem from './instagram-widget-item'
 
-const MAX_IMAGES = 8
+const MAX_IMAGES = {
+  default: 8,
+  showMore: 16
+}
 
 const getHasFatalError = state => getInstagramWidget(state).state === FAILURE
 const getIsLoading = state => getInstagramWidget(state).state !== SUCCESS
@@ -47,6 +53,7 @@ export default () => {
 
   const [currentImage, setCurrentImage] = useState(0)
   const [viewerIsOpen, setViewerIsOpen] = useState(false)
+  const [isShowingMore, setIsShowingMore] = useState(false)
 
   const openLightbox = useCallback((event, { photo, index }) => {
     setCurrentImage(index)
@@ -69,12 +76,11 @@ export default () => {
     </CallToAction>
   )
 
+  const countItemsToRender = isShowingMore ? MAX_IMAGES.showMore : MAX_IMAGES.default
+
   return (
     <Widget id='instagram' hasFatalError={hasFatalError}>
-      <WidgetHeader
-        aside={callToAction}
-        icon={faInstagram}
-      >
+      <WidgetHeader aside={callToAction} icon={faInstagram}>
         Instagram
       </WidgetHeader>
 
@@ -87,7 +93,7 @@ export default () => {
             gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(3, 1fr)', '', 'repeat(4, 1fr)']
           }}
         >
-          {(isLoading ? Array(MAX_IMAGES).fill({}) : media).slice(0, MAX_IMAGES).map((post, idx) => (
+          {(isLoading ? Array(countItemsToRender).fill({}) : media).slice(0, countItemsToRender).map((post, idx) => (
             <ReactPlaceholder
               customPlaceholder={
                 <div className='image-placeholder'>
@@ -112,6 +118,18 @@ export default () => {
           ))}
         </Grid>
       </div>
+
+      {!isLoading && (
+        <div sx={{ my: 4, textAlign: 'center' }}>
+          <Button onClick={() => setIsShowingMore(!isShowingMore)}>
+            {
+              isShowingMore
+                ? 'Show Less'
+                : 'Show More'
+            }
+          </Button>
+        </div>
+      )}
 
       <ModalGateway>
         {viewerIsOpen && (

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -124,6 +124,21 @@ export default merge(tailwind, {
     }
   },
 
+  buttons: {
+    primary: {
+      color: 'background',
+      bg: 'primary',
+    },
+    secondary: {
+      color: 'background',
+      bg: 'secondary',
+    },
+    gray: {
+      color: 'background',
+      bg: 'gray',
+    },
+  },
+
   cards: {
     /* The <Card /> default style. Used when no variant is defined. */
     primary: {


### PR DESCRIPTION
This PR adds a new Show More button to the Instagram widget that doubles the number of items rendered.

https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/2d27b0f7-289a-487f-a23d-abd35dea552e

