### PR TITLE
fix: overflow behind IG images on home page

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -8,7 +8,7 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
 >
   <img
     alt="Instagram post thumbnail"
-    className="instagram-item-image css-t0307v-InstagramWidgetItem"
+    className="instagram-item-image css-nak59c-InstagramWidgetItem"
     crossOrigin="anonymous"
     height="280"
     loading="lazy"

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -37,7 +37,6 @@ const InstagramWidgetItem = ({ handleClick, index, post: { caption, cdnMediaURL,
         width='280'
         alt='Instagram post thumbnail'
         sx={{
-          borderRadius: '8px',
           width: '100%',
           height: '100%',
           transition: `all 1.5s ease`,

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -347,6 +347,8 @@ export default merge(tailwind, {
       border: `none`,
       boxShadow: `md`,
       cursor: `pointer`,
+      overflow: `hidden`,
+      borderRadius: `8px`,
       p: 0
     },
 

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
This PR fixes a bug visible in the Instagram widget pictures.

## Before

Theres a white background visible behind the edges of the Instagram items. It's hard to notice, but if you zoom or look closely, you can find it.

<img width="1700" alt="Screenshot 2024-06-19 at 1 50 40 AM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/923dfd82-2502-411d-83b8-d21ebd4c0da0">

## After

After this change, the overflow has been cut off by the container element.

<img width="1700" alt="Screenshot 2024-06-19 at 1 54 13 AM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/8ec9fb80-1e32-44b4-a27a-84855a3c113a">
