### PR TITLE
fix: rss feed guid with invalid URL

### DIFF
--- a/www.chrisvogt.me/plugins/gatsby-plugin-feed.config.js
+++ b/www.chrisvogt.me/plugins/gatsby-plugin-feed.config.js
@@ -27,7 +27,7 @@ module.exports = {
               date: edge.node.frontmatter.date,
               description: edge.node.excerpt,
               feed_url: site.siteMetadata.baseUrl + '/rss.xml',
-              guid: site.siteMetadata.baseURL + edge.node.fields.slug,
+              guid: buildFeedItemUrl(site.siteMetadata.baseURL, edge.node.fields.category, edge.node.fields.slug),
               ...(hasImage ? { image: edge.node.frontmatter.banner } : {}),
               url: buildFeedItemUrl(site.siteMetadata.baseURL, edge.node.fields.category, edge.node.fields.slug)
             })


### PR DESCRIPTION
This PR fixes an invalid URL I found in my rss feed's guid field.

```xml
<link>https://www.chrisvogt.me/personal/2024-evolution-of-this-blog</link>
<guid isPermaLink="false">https://www.chrisvogt.me2024-evolution-of-this-blog</guid>
<pubDate>Tue, 18 Jun 2024 20:21:00 GMT</pubDate>
```