### PR TITLE
feat: temporary naver site verification <meta> tag

### DIFF
--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -60,6 +60,7 @@ export const Head = () => (
   >
     <meta property="og:url" content="https://www.chrisvogt.me" />
     <meta property="og:type" content="website" />
+    <meta name="naver-site-verification" content="9f0709febb11d387af7361215096bf7e0a35fc82" />
     <script type="application/ld+json">
       {`{
         "@context": "https://schema.org",


### PR DESCRIPTION
Adds a new, temporary <meta /> tag to the home page that I'll use for Naver verification.

<img width="1604" alt="Screenshot 2024-06-22 at 11 56 12 AM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/8dfcd479-eb5b-4fc9-bc3e-e37d2ad60225">
