### PR TITLE
feat: enlarge blog post image artwork

### DIFF
--- a/theme/src/styles/global.css
+++ b/theme/src/styles/global.css
@@ -23,8 +23,14 @@ body,
 article.c1v0-blog-post img {
   max-width: 100%;
   border-radius: 8px;
+  margin-bottom: 1.5rem;
   /* Hack to give these images a light background color in dark mode. */
   background-color: #fcfcfc;
+  /* Matches the Theme UI default breakpoints. See https://theme-ui.com/theme-spec#breakpoints. */
+  @media (min-width: 56em) and (orientation: landscape) {
+    max-width: 120%;
+    margin-left: -10%;
+  }
 }
 
 /* NOTE(cvogt): overrides the default react-photo-gallery footer style */


### PR DESCRIPTION
This PR updates the blog post styles so that the images are 20% wider than the blog post text.

| Before | After |
|--------|-------|
|    <img width="1591" alt="before" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/a77ef264-1cc8-4989-bbec-5eaeb75529fb">    |    <img width="1591" alt="after" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/b7645567-024b-4231-bd5a-031e62c422f5">   |