### PR TITLE
feat: update the footer with ❤️, 🌈 and RSS

### DIFF
--- a/theme/gatsby-config.js
+++ b/theme/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = () => ({
     avatarURL: 'https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1573025803/avatar_2x_srlojo',
     baseURL: 'https://www.chrisvogt.me',
     description: 'My personal website. A GatsbyJS blog with built-in Instagram, Goodreads, GitHub and Spotify widgets.',
-    footerText: 'Made in San Francisco',
+    footerText: 'Made with ❤️ in 🌈 Castro, San Francisco',
     headline: 'www.chrisvogt.me',
     imageURL: '',
     languageCode: 'en',

--- a/theme/src/components/footer/footer.js
+++ b/theme/src/components/footer/footer.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { Container, jsx } from 'theme-ui'
+import { Container, jsx, Link } from 'theme-ui'
 
 import Profiles from './profiles'
 import SwoopTop from '../swoops/swoop-top'
@@ -19,7 +19,8 @@ export default () => {
           <Profiles />
         </div>
 
-        {footerText ? <div>{footerText}</div> : null}
+        <span>{footerText ? <div>{footerText}</div> : null}</span>
+        <span><Link href='/rss.xml'>Subscribe via RSS</Link></span>
       </Container>
     </footer>
   )


### PR DESCRIPTION
This PR polishes the page footer, expanding on the text and adding a new link to the RSS feed.

| Before | After |
|--------|-------|
|    <img width="1530" alt="before" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/ad39e6e8-4c60-47f2-864c-ed6799c4e714">    |    <img width="1530" alt="after" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/0a2e56f3-2f50-42f4-8121-22e2c54bbbf0">   |



