### PR TITLE
fix: new design on Webkit browsers

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.28.7",
+  "version": "0.29.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/layout.spec.js.snap
+++ b/theme/src/components/__snapshots__/layout.spec.js.snap
@@ -30,6 +30,7 @@ exports[`Layout matches the snapshot 1`] = `
     <div
       style={
         {
+          "WebkitBackdropFilter": "blur(100px)",
           "backdropFilter": "blur(100px)",
           "backgroundColor": "rgba(75, 0, 130, 0.02)",
           "height": "100%",

--- a/theme/src/components/animated-background.js
+++ b/theme/src/components/animated-background.js
@@ -132,6 +132,7 @@ const AnimatedBackground = () => {
         height: '100%', 
         backgroundColor: 'rgba(75, 0, 130, 0.02)', // Dark purple overlay
         backdropFilter: 'blur(100px)', 
+        WebkitBackdropFilter: 'blur(100px)', /* Safari */
         pointerEvents: 'none' // Ensure the overlay doesn't block interactions
       }}></div>
     </div>

--- a/theme/src/components/home-header-content.js
+++ b/theme/src/components/home-header-content.js
@@ -47,7 +47,7 @@ const HomeHeaderContent = () => {
       </Themed.p>
       <Themed.p>
         Welcome to my digital garden, where I share my passions, projects, and learnings. This site is designed and built by me and is published
-        open source to inspire and help others grow and learn.
+        open source to inspire and help others grow and learn with me.
       </Themed.p>
     </div>
   )

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -38,6 +38,7 @@ const HomeTemplate = props => {
                   background: 'rgba(255, 255, 255, 0.07)',
                   borderRadius: '10px',
                   backdropFilter: 'blur(10px)',
+                  WebkitBackdropFilter: 'blur(10px)',
                   boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
                   border: '1px solid rgba(255, 255, 255, 0.3)',
 

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
I should have checked this in Safari before rolling it out. 🤦🏼 This PR covers Safari for the new design update.

## Before

<img width="1706" alt="Screenshot 2024-07-04 at 2 42 02 PM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/53f08f2f-a8fe-45b3-98ca-dee2f489d0b9">

## After

<img width="1706" alt="Screenshot 2024-07-04 at 2 41 57 PM" src="https://github.com/chrisvogt/gatsby-theme-chrisvogt/assets/1934719/83eb71d6-3043-437f-ad27-9bb249df9e27">
