### PR TITLE
feat: add a skip nav link to improve keyboard navigation

### DIFF
--- a/theme/gatsby-browser.js
+++ b/theme/gatsby-browser.js
@@ -4,3 +4,13 @@ import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 import './src/styles/global.css'
 
 export { default as wrapRootElement } from './wrapRootElement'
+
+// See https://fossies.org/linux/gatsby/examples/using-reach-skip-nav/README.md
+export const onRouteUpdate = ({ location, prevLocation }) => {
+  if (prevLocation !== null) {
+    const skipLink = document.querySelector('[data-reach-skip-link]') // Ccomes with the <SkipNavLink> component.
+    if (skipLink) {
+      skipLink.focus()
+    }
+  }
+}

--- a/theme/package.json
+++ b/theme/package.json
@@ -63,6 +63,7 @@
     "@mdx-js/loader": "3.0.1",
     "@mdx-js/mdx": "3.0.1",
     "@mdx-js/react": "3.0.1",
+    "@reach/skip-nav": "^0.18.0",
     "@reduxjs/toolkit": "^2.2.6",
     "@theme-ui/color": "^0.16.0",
     "@theme-ui/components": "^0.16.0",

--- a/theme/src/components/__snapshots__/layout.spec.js.snap
+++ b/theme/src/components/__snapshots__/layout.spec.js.snap
@@ -1,72 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Layout matches the snapshot 1`] = `
-<div
-  className="css-tvtok6-Layout"
->
+[
+  <a
+    data-reach-skip-link=""
+    data-reach-skip-nav-link=""
+    href="#reach-skip-nav"
+  >
+    Skip to content
+  </a>,
   <div
-    style={
-      {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
-    }
+    className="css-tvtok6-Layout"
   >
-    <canvas
-      style={
-        {
-          "display": "block",
-          "height": "100%",
-          "left": 0,
-          "position": "absolute",
-          "top": 0,
-          "width": "100%",
-        }
-      }
-    />
     <div
       style={
         {
-          "WebkitBackdropFilter": "blur(100px)",
-          "backdropFilter": "blur(100px)",
-          "backgroundColor": "rgba(75, 0, 130, 0.02)",
-          "height": "100%",
+          "bottom": 0,
           "left": 0,
-          "pointerEvents": "none",
           "position": "absolute",
+          "right": 0,
           "top": 0,
-          "width": "100%",
         }
       }
-    />
-  </div>
-  <header
-    className="css-1jqf6qp-Layout"
-    role="banner"
-  >
-    <div
-      className="MOCK__TopNavigation"
-    />
-  </header>
-  <main
-    role="main"
-  >
-    <div
-      className="fake-website"
     >
-      <h1>
-        Fake Website
-      </h1>
-      <p>
-        Lorum ipsum dolor sit amet.
-      </p>
+      <canvas
+        style={
+          {
+            "display": "block",
+            "height": "100%",
+            "left": 0,
+            "position": "absolute",
+            "top": 0,
+            "width": "100%",
+          }
+        }
+      />
+      <div
+        style={
+          {
+            "WebkitBackdropFilter": "blur(100px)",
+            "backdropFilter": "blur(100px)",
+            "backgroundColor": "rgba(75, 0, 130, 0.02)",
+            "height": "100%",
+            "left": 0,
+            "pointerEvents": "none",
+            "position": "absolute",
+            "top": 0,
+            "width": "100%",
+          }
+        }
+      />
     </div>
-  </main>
-  <div
-    className="MOCK__Footer"
-  />
-</div>
+    <header
+      className="css-1jqf6qp-Layout"
+      role="banner"
+    >
+      <div
+        className="MOCK__TopNavigation"
+      />
+    </header>
+    <main
+      role="main"
+    >
+      <div
+        data-reach-skip-nav-content=""
+        id="reach-skip-nav"
+      />
+      <div
+        className="fake-website"
+      >
+        <h1>
+          Fake Website
+        </h1>
+        <p>
+          Lorum ipsum dolor sit amet.
+        </p>
+      </div>
+    </main>
+    <div
+      className="MOCK__Footer"
+    />
+  </div>,
+]
 `;

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,5 +1,8 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import React from 'react';
+import { SkipNavLink, SkipNavContent } from '@reach/skip-nav'
+import '@reach/skip-nav/styles.css' //this will show/hide the link on focus
 
 import BackgroundPattern from './animated-background'
 import Footer from './footer'
@@ -13,33 +16,37 @@ import TopNavigation from './top-navigation'
  * to extend this component and attach additional contexts and providers.
  */
 const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => (
-  <div sx={{
-    backgroundColor: 'background',
-    position: 'relative', // stretch to full height
-    display: 'flex',
-    flexDirection: 'column',
-    flexGrow: 1,
-    color: theme => theme?.colors?.text
-  }}>
-    <BackgroundPattern />
+  <>
+    <SkipNavLink />
+    <div sx={{
+      backgroundColor: 'background',
+      position: 'relative', // stretch to full height
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+      color: theme => theme?.colors?.text
+    }}>
+      <BackgroundPattern />
 
-    {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
-    {!hideHeader && (
-      <header role='banner' sx={{ position: 'relative' }}>
-        <TopNavigation />
-      </header>
-    )}
+      {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
+      {!hideHeader && (
+        <header role='banner' sx={{ position: 'relative' }}>
+          <TopNavigation />
+        </header>
+      )}
 
-    {
-      disableMainWrapper ? children : (
-        <main role='main'>
-          {children}
-        </main>
-      )
-    }
+      {
+        disableMainWrapper ? children : (
+          <main role='main'>
+            <SkipNavContent />
+            {children}
+          </main>
+        )
+      }
 
-    {!hideFooter && <Footer />}
-  </div>
+      {!hideFooter && <Footer />}
+    </div>
+  </>
 )
 
 export default Layout

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 import { jsx, Container, Grid } from 'theme-ui'
 import { graphql } from 'gatsby'
+import { SkipNavContent } from '@reach/skip-nav'
 
 import Footer from '../components/footer'
 import HomeHeaderContent from '../components/home-header-content'
@@ -33,6 +34,7 @@ const HomeTemplate = props => {
               <HomeNavigation />
             </aside>
             <main role='main'>
+              <SkipNavContent />
               <div
                 sx={{
                   position: 'relative',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,6 +2598,18 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
+"@reach/polymorphic@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/polymorphic/-/polymorphic-0.18.0.tgz#2fe42007a774e06cdbc8e13e0d46f2dc30f2f1ed"
+  integrity sha512-N9iAjdMbE//6rryZZxAPLRorzDcGBnluf7YQij6XDLiMtfCj1noa7KyLpEc/5XCIB/EwhX3zCluFAwloBKdblA==
+
+"@reach/skip-nav@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/skip-nav/-/skip-nav-0.18.0.tgz#9f72ba7ffcd8231c5d3aa10829ef68806e5bf759"
+  integrity sha512-7XKHX0NNTz9VJw1d+ZRuu3KhKSOZTIHSbHUuv7qKKPwSNApDa+dVGqR/I7dKwyB/CDFMXO4iEz4XLtOmvi0FEg==
+  dependencies:
+    "@reach/polymorphic" "0.18.0"
+
 "@reduxjs/toolkit@^2.2.6":
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.2.6.tgz#4a8356dad9d0c1ab255607a555d492168e0e3bc1"


### PR DESCRIPTION
This PR adds a [skip nav link](https://webaim.org/techniques/skipnav/) using [@reach/skip-nav](https://reach.tech/skip-nav/) to improve keyboard navigation. As you navigate between pages, it's cumbersome to TAB through the header links every page. After this change, a new button appears at the top of the page if when you first begin to TAB through the content, allowing you to jump to the main content area.