### PR TITLE
chore: replace defaultProps with JS defaults

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -93,7 +93,6 @@
     "lodash": "^4.17.21",
     "lottie-react-web": "^2.2.2",
     "prismjs": "^1.29.0",
-    "prop-types": "^15.8.1",
     "react": "^18",
     "react-dark-mode-toggle-2": "github:chrisvogt/react-dark-mode-toggle-2#button-attributes-build",
     "react-dom": "^18",

--- a/theme/src/components/artwork/book.js
+++ b/theme/src/components/artwork/book.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import PropTypes from 'prop-types'
 import { useId } from 'react'
 
 const Book = ({ thumbnailURL, title }) => {
@@ -48,11 +47,6 @@ const Book = ({ thumbnailURL, title }) => {
       </g>
     </svg>
   )
-}
-
-Book.propTypes = {
-  thumbnailURL: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired
 }
 
 export default Book

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -1,9 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import PropTypes from 'prop-types'
-
 import SwoopBottom from './swoops/swoop-bottom'
-// import trianglify from './artwork/trianglify.svg'
 
 /**
  * Header
@@ -28,10 +25,6 @@ const Header = ({ children, styles }) => {
       </div>
     </header>
   )
-}
-
-Header.propTypes = {
-  children: PropTypes.node.isRequired
 }
 
 export default Header

--- a/theme/src/components/header.js
+++ b/theme/src/components/header.js
@@ -31,12 +31,7 @@ const Header = ({ children, styles }) => {
 }
 
 Header.propTypes = {
-  children: PropTypes.node.isRequired,
-  showSwoop: PropTypes.bool
-}
-
-Header.defaultProps = {
-  showSwoop: false
+  children: PropTypes.node.isRequired
 }
 
 export default Header

--- a/theme/src/components/header.spec.js
+++ b/theme/src/components/header.spec.js
@@ -10,7 +10,7 @@ describe('Header', () => {
     const tree = renderer
       .create(
         <TestProvider>
-          <Header showSwoop hideTopPadding>
+          <Header hideTopPadding>
             {headline}
           </Header>
         </TestProvider>

--- a/theme/src/components/lazy-load.js
+++ b/theme/src/components/lazy-load.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { useState } from 'react'
-import PropTypes from 'prop-types'
 import VisibilitySensor from 'react-visibility-sensor'
 
 const DefaultPlaceholder = ({
@@ -42,13 +41,6 @@ const LazyLoad = ({
       {hasBeenVisible ? children : placeholder}
     </VisibilitySensor>
   )
-}
-
-LazyLoad.propTypes = {
-  children: PropTypes.node.isRequired,
-  height: PropTypes.string,
-  placholder: PropTypes.element,
-  width: PropTypes.string
 }
 
 export default LazyLoad

--- a/theme/src/components/lazy-load.js
+++ b/theme/src/components/lazy-load.js
@@ -4,7 +4,10 @@ import { useState } from 'react'
 import PropTypes from 'prop-types'
 import VisibilitySensor from 'react-visibility-sensor'
 
-const DefaultPlaceholder = () => (
+const DefaultPlaceholder = ({
+  height = '100%',
+  width = '100%'
+}) => (
   <div
     sx={{
       minHeight: `1px`,
@@ -22,7 +25,10 @@ const DefaultPlaceholder = () => (
  *
  * Hides a component until it's been visible in the viewport.
  */
-const LazyLoad = ({ children, placeholder }) => {
+const LazyLoad = ({
+  children,
+  placeholder = DefaultPlaceholder
+}) => {
   const [hasBeenVisible, setHasBeenVisible] = useState(false)
 
   const onChange = isVisible => {
@@ -43,12 +49,6 @@ LazyLoad.propTypes = {
   height: PropTypes.string,
   placholder: PropTypes.element,
   width: PropTypes.string
-}
-
-LazyLoad.defaultProps = {
-  height: '100%',
-  placholder: DefaultPlaceholder,
-  width: '100%'
 }
 
 export default LazyLoad

--- a/theme/src/components/seo.js
+++ b/theme/src/components/seo.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { useThemeUI } from 'theme-ui'
 
 import useSiteMetadata from '../hooks/use-site-metadata'
@@ -50,15 +49,6 @@ const Seo = ({
       {children}
     </>
   )
-}
-
-Seo.propTypes = {
-  article: PropTypes.bool,
-  description: PropTypes.string,
-  image: PropTypes.string,
-  keywords: PropTypes.string,
-  pathname: PropTypes.string,
-  title: PropTypes.string
 }
 
 export default Seo

--- a/theme/src/components/top-navigation.js
+++ b/theme/src/components/top-navigation.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, Container } from 'theme-ui'
 import { Link } from 'gatsby'
-import PropTypes from 'prop-types'
 import { Themed } from '@theme-ui/mdx'
 
 import ColorToggle from '../components/color-toggle'
@@ -76,12 +75,6 @@ const TopNavigation = ({ hideBrandLink, hideMenuItems }) => {
       </Container>
     </Themed.div>
   )
-}
-
-TopNavigation.propTypes = {
-  hideBackground: PropTypes.bool,
-  hideBrandLink: PropTypes.bool,
-  hideMenuItems: PropTypes.bool
 }
 
 export default TopNavigation

--- a/theme/src/components/widgets/call-to-action.js
+++ b/theme/src/components/widgets/call-to-action.js
@@ -3,7 +3,6 @@ import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Bars } from 'svg-loaders-react'
 import { Link } from 'gatsby'
-import PropTypes from 'prop-types'
 
 /**
  * Call To Action
@@ -43,19 +42,6 @@ const CallToAction = ({ children, isLoading = false, title, to, url }) => {
       {children}
     </LinkComponent>
   )
-}
-
-CallToAction.propTypes = {
-  /** Content rendered within the call to action container. */
-  children: PropTypes.node.isRequired,
-  /** Renders a loading indicator when true. */
-  isLoading: PropTypes.bool,
-  /** The title attribute for the hyperlink. */
-  title: PropTypes.string.isRequired,
-  /** Use instead of href to define a Gatsby router destination. */
-  to: PropTypes.string,
-  /** The URL for the hyperlink's navigation. */
-  url: PropTypes.string
 }
 
 export default CallToAction

--- a/theme/src/components/widgets/call-to-action.js
+++ b/theme/src/components/widgets/call-to-action.js
@@ -11,8 +11,8 @@ import PropTypes from 'prop-types'
  * Each widget contains a call to action next to its headline. Can optionally render
  * a loading indicator when `isLoading` is set.
  */
-const CallToAction = ({ children, isLoading, title, to, url }) => {
-  const LinkComponent = to ? Link : Themed.a;
+const CallToAction = ({ children, isLoading = false, title, to, url }) => {
+  const LinkComponent = to ? Link : Themed.a
   return isLoading ? (
     <Bars fill='#1E90FF' width='24' height='24' sx={{ verticalAlign: `middle` }} />
   ) : (
@@ -56,10 +56,6 @@ CallToAction.propTypes = {
   to: PropTypes.string,
   /** The URL for the hyperlink's navigation. */
   url: PropTypes.string
-}
-
-CallToAction.defaultProps = {
-  isLoading: false
 }
 
 export default CallToAction

--- a/theme/src/components/widgets/card-footer.js
+++ b/theme/src/components/widgets/card-footer.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import PropTypes from 'prop-types'
 
 const CardFooter = ({ children, customStyles }) => (
   <div
@@ -15,10 +14,5 @@ const CardFooter = ({ children, customStyles }) => (
     {children}
   </div>
 )
-
-CardFooter.propTypes = {
-  /** The content for the card footer. */
-  children: PropTypes.node.isRequired
-}
 
 export default CardFooter

--- a/theme/src/components/widgets/github/last-pull-request.js
+++ b/theme/src/components/widgets/github/last-pull-request.js
@@ -4,7 +4,6 @@ import { Themed } from '@theme-ui/mdx'
 import { Box, Card, Heading } from '@theme-ui/components'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
-import PropTypes from 'prop-types'
 
 import CardFooter from '../card-footer'
 import ViewExternal from '../view-external'
@@ -60,24 +59,6 @@ const LastPullRequest = ({ isLoading, pullRequest = {} }) => {
       </Themed.a>
     </Box>
   )
-}
-
-LastPullRequest.propTypes = {
-  /** Sets the component in a loading state when true. */
-  isLoading: PropTypes.bool,
-  /** The pull request on GitHub. */
-  pullRequest: PropTypes.shape({
-    /** The # of the pull request on GitHub. */
-    number: PropTypes.number,
-    repository: PropTypes.shape({
-      /** The name of the subject repository. */
-      name: PropTypes.string
-    }),
-    /** The pull request content to render. */
-    title: PropTypes.string,
-    /** The URL to hyperlink to. */
-    url: PropTypes.string
-  })
 }
 
 export default LastPullRequest

--- a/theme/src/components/widgets/github/pinned-item-card.js
+++ b/theme/src/components/widgets/github/pinned-item-card.js
@@ -15,12 +15,8 @@ const rendererRegistry = {
   [REPOSITORY]: RepositoryContent
 }
 
-const PinnedItemCard = ({ item, type }) => (
-  <Card
-    variant='actionCard'
-  >
-      {rendererRegistry[type] && rendererRegistry[type](item)}
-  </Card>
+const PinnedItemCard = ({ item, type = PLACEHOLDER }) => (
+  <Card variant='actionCard'>{rendererRegistry[type] && rendererRegistry[type](item)}</Card>
 )
 
 PinnedItemCard.propTypes = {
@@ -28,10 +24,6 @@ PinnedItemCard.propTypes = {
   item: PropTypes.object,
   /** The type of pinned item. */
   type: PropTypes.oneOf([PLACEHOLDER, REPOSITORY])
-}
-
-PinnedItemCard.defaultProps = {
-  type: PLACEHOLDER
 }
 
 export default PinnedItemCard

--- a/theme/src/components/widgets/github/pinned-item-card.js
+++ b/theme/src/components/widgets/github/pinned-item-card.js
@@ -2,8 +2,6 @@
 import { jsx } from 'theme-ui'
 import { Card } from '@theme-ui/components'
 
-import PropTypes from 'prop-types'
-
 import PlaceholderContent from './renderers/placeholder'
 import RepositoryContent from './renderers/repository'
 
@@ -18,12 +16,5 @@ const rendererRegistry = {
 const PinnedItemCard = ({ item, type = PLACEHOLDER }) => (
   <Card variant='actionCard'>{rendererRegistry[type] && rendererRegistry[type](item)}</Card>
 )
-
-PinnedItemCard.propTypes = {
-  /** The pinned item content. */
-  item: PropTypes.object,
-  /** The type of pinned item. */
-  type: PropTypes.oneOf([PLACEHOLDER, REPOSITORY])
-}
 
 export default PinnedItemCard

--- a/theme/src/components/widgets/github/pinned-items.js
+++ b/theme/src/components/widgets/github/pinned-items.js
@@ -2,7 +2,6 @@
 import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Box, Heading } from '@theme-ui/components'
-import PropTypes from 'prop-types'
 
 import PinnedItemCard from './pinned-item-card'
 
@@ -52,15 +51,6 @@ const PinnedItems = ({ isLoading, items = [], placeholderCount = 4 }) => {
       </Themed.div>
     </Box>
   )
-}
-
-PinnedItems.propTypes = {
-  /** Sets the component in a loading state when true. */
-  isLoading: PropTypes.bool,
-  /** The pinned items content to render. */
-  items: PropTypes.arrayOf(PropTypes.object),
-  /** The number of placeholder items to render. */
-  placeholderCount: PropTypes.number
 }
 
 export default PinnedItems

--- a/theme/src/components/widgets/github/renderers/repository.js
+++ b/theme/src/components/widgets/github/renderers/repository.js
@@ -2,7 +2,6 @@
 import { jsx } from 'theme-ui'
 import { Flex, Heading } from '@theme-ui/components'
 import ago from 's-ago'
-import PropTypes from 'prop-types'
 
 import CardFooter from '../../card-footer'
 import ViewExternal from '../../view-external'
@@ -26,16 +25,5 @@ const Repository = ({ description, nameWithOwner, updatedAt }) => (
     </CardFooter>
   </Flex>
 )
-
-Repository.propTypes = {
-  /** @prop {String} description The description of the repository. */
-  description: PropTypes.string.isRequired,
-  /** @prop {String} nameWithOwner The repository's name with owner. */
-  nameWithOwner: PropTypes.string.isRequired,
-  /** @prop {String} openGraphImageUrl The image used to represent this repository in Open Graph data. */
-  openGraphImageUrl: PropTypes.string.isRequired,
-  /** @prop {String} updatedAt Identifies the date and time when the object was last updated. ISO-8601 encoded. */
-  updatedAt: PropTypes.string.isRequired
-}
 
 export default Repository

--- a/theme/src/components/widgets/goodreads/book-link.js
+++ b/theme/src/components/widgets/goodreads/book-link.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
-import PropTypes from 'prop-types'
 import Book from '../../artwork/book'
 
 const BookLink = ({ infoLink, thumbnailURL, title }) => (
@@ -9,11 +8,5 @@ const BookLink = ({ infoLink, thumbnailURL, title }) => (
     <Book thumbnailURL={thumbnailURL} title={`${title} on Google Books`} />
   </Themed.a>
 )
-
-BookLink.propTypes = {
-  title: PropTypes.string.isRequired,
-  infoLink: PropTypes.string.isRequired,
-  thumbnailURL: PropTypes.string.isRequired
-}
 
 export default BookLink

--- a/theme/src/components/widgets/goodreads/user-profile.js
+++ b/theme/src/components/widgets/goodreads/user-profile.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
 import { Card, Heading } from '@theme-ui/components'
-import PropTypes from 'prop-types'
 import Placeholder from 'react-placeholder'
 
 import isDarkMode from '../../../helpers/isDarkMode'
@@ -68,17 +67,6 @@ const UserProfile = ({ isLoading, profile }) => {
       </div>
     </Card>
   )
-}
-
-UserProfile.propTypes = {
-  /** Sets the component in a loading state when true. */
-  isLoading: PropTypes.bool,
-  /** The Goodreads user profile. */
-  profile: PropTypes.shape({
-    favoriteBooks: PropTypes.string,
-    friendsCount: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    readcount: PropTypes.number
-  })
 }
 
 export default UserProfile

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -3,7 +3,6 @@ import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { Box, Card, Heading } from '@theme-ui/components'
 import ago from 's-ago'
-import PropTypes from 'prop-types'
 import Placeholder from 'react-placeholder'
 import { TextRow } from 'react-placeholder/lib/placeholders'
 
@@ -75,19 +74,6 @@ const UserStatus = ({ isLoading, status, actorName }) => {
       </Themed.a>
     </Box>
   )
-}
-
-UserStatus.propTypes = {
-  /** The name of the person the status is about. */
-  actorName: PropTypes.string,
-  /** Widget is in a loading state if true. */
-  isLoading: PropTypes.bool,
-  /** The Goodreads user status object. */
-  status: PropTypes.shape({
-    actionText: PropTypes.string,
-    updated: PropTypes.string,
-    link: PropTypes.string
-  })
 }
 
 export default UserStatus

--- a/theme/src/components/widgets/metric-card.js
+++ b/theme/src/components/widgets/metric-card.js
@@ -13,7 +13,7 @@ import Placeholder from 'react-placeholder'
  * the social widgets. They typically contain an insight for the social
  * profile (e.g., Followers: 24).
  */
-const MetricCard = ({ title, value, showPlaceholder }) => {
+const MetricCard = ({ title, value, showPlaceholder = false }) => {
   const { colorMode } = useThemeUI()
   const variant = isDarkMode(colorMode) ? 'metricCardDark' : 'metricCard'
 
@@ -34,10 +34,6 @@ MetricCard.propTypes = {
   title: PropTypes.string.isRequired,
   /** The value of the metric. */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-}
-
-MetricCard.defaultProps = {
-  placeholder: false
 }
 
 export default MetricCard

--- a/theme/src/components/widgets/metric-card.js
+++ b/theme/src/components/widgets/metric-card.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
 import { Card } from '@theme-ui/components'
-import PropTypes from 'prop-types'
 
 import isDarkMode from '../../helpers/isDarkMode'
 import Placeholder from 'react-placeholder'
@@ -25,15 +24,6 @@ const MetricCard = ({ title, value, showPlaceholder = false }) => {
       </Placeholder>
     </Card>
   )
-}
-
-MetricCard.propTypes = {
-  /** An animated placeholder is rendered when true. */
-  showPlaceholder: PropTypes.bool,
-  /** The title of the metric. */
-  title: PropTypes.string.isRequired,
-  /** The value of the metric. */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
 }
 
 export default MetricCard

--- a/theme/src/components/widgets/profile-metrics-badge.js
+++ b/theme/src/components/widgets/profile-metrics-badge.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { Badge, jsx } from 'theme-ui'
-import PropTypes from 'prop-types'
 
 const ProfileMetricsBadge = ({ isLoading, metrics }) => (
   <div
@@ -20,18 +19,5 @@ const ProfileMetricsBadge = ({ isLoading, metrics }) => (
     ))}
   </div>
 )
-
-ProfileMetricsBadge.propTypes = {
-  /** Sets the component in a loading state when true. */
-  isLoading: PropTypes.bool,
-  /** The metrics for the user profile. */
-  metrics: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string,
-      displayName: PropTypes.string,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-    })
-  )
-}
 
 export default ProfileMetricsBadge

--- a/theme/src/components/widgets/spotify/track-preview.js
+++ b/theme/src/components/widgets/spotify/track-preview.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
-import PropTypes from 'prop-types'
 
 const TrackPreview = ({ link, name, thumbnailURL }) => (
   <Themed.a
@@ -22,11 +21,5 @@ const TrackPreview = ({ link, name, thumbnailURL }) => (
     />
   </Themed.a>
 )
-
-TrackPreview.propTypes = {
-  link: PropTypes.string.isRequired,
-  name: PropTypes.string.isRequired,
-  thumbnailURL: PropTypes.string.isRequired
-}
 
 export default TrackPreview

--- a/theme/src/components/widgets/status-card.js
+++ b/theme/src/components/widgets/status-card.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
 import { Card } from '@theme-ui/components'
-import PropTypes from 'prop-types'
 
 import isDarkMode from '../../helpers/isDarkMode'
 
@@ -14,11 +13,6 @@ const StatusCard = ({ message }) => {
       {message}
     </Card>
   )
-}
-
-StatusCard.propTypes = {
-  /** The GitHub user's status message. */
-  message: PropTypes.string
 }
 
 export default StatusCard

--- a/theme/src/components/widgets/widget-header.js
+++ b/theme/src/components/widgets/widget-header.js
@@ -2,7 +2,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Heading } from '@theme-ui/components'
 import { jsx } from 'theme-ui'
-import PropTypes from 'prop-types'
 
 const headerStyles = {
   textAlign: [`center`, `left`],
@@ -24,12 +23,5 @@ const WidgetHeader = ({ aside, children, icon }) => (
     {aside && <div sx={asideStyles}>{aside}</div>}
   </header>
 )
-
-WidgetHeader.propTypes = {
-  /** The content to render in the headline. */
-  children: PropTypes.node.isRequired,
-  /** The icon to render. Usually an SVG. */
-  icon: PropTypes.object
-}
 
 export default WidgetHeader

--- a/theme/src/components/widgets/widget.js
+++ b/theme/src/components/widgets/widget.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import { jsx, useThemeUI } from 'theme-ui'
-import PropTypes from 'prop-types'
 import isDarkMode from '../../helpers/isDarkMode'
 
 const widgetStyles = {
@@ -72,13 +71,6 @@ const Widget = ({ children, hasFatalError, id, styleOverrides = {} }) => {
       {children}
     </section>
   )
-}
-
-Widget.propTypes = {
-  /** The elements to render within the widget. */
-  children: PropTypes.node.isRequired,
-  /** An id added to the widget wrapper element. */
-  id: PropTypes.string
 }
 
 export default Widget

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -2,7 +2,6 @@
 import { Container, Flex, jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { graphql } from 'gatsby'
-import PropTypes from 'prop-types'
 
 import Layout from '../components/layout'
 import PageHeader from '../components/blog/page-header'
@@ -72,13 +71,6 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
       </Flex>
     </Layout>
   )
-}
-
-MediaTemplate.propTypes = {
-  children: PropTypes.node,
-  data: PropTypes.shape({
-    mdx: PropTypes.object.isRequired
-  }).isRequired
 }
 
 export const Head = ({ data: { mdx } }) => {

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -17,7 +17,6 @@ const getTitle = mdx => mdx.frontmatter.title
 
 const MediaTemplate = ({ data: { mdx }, children }) => {
   const category = mdx.fields.category?.replace('Photography/', '')
-  console.log(category)
   const date = mdx.frontmatter.date
   const soundcloudId = mdx.frontmatter.soundcloudId
   const title = getTitle(mdx)

--- a/theme/src/templates/post.js
+++ b/theme/src/templates/post.js
@@ -2,7 +2,6 @@
 import { Container, jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { graphql } from 'gatsby'
-import PropTypes from 'prop-types'
 
 import Layout from '../components/layout'
 import PageHeader from '../components/blog/page-header'
@@ -43,12 +42,6 @@ const PostTemplate = ({ children, data }) => {
       </Themed.div>
     </Layout>
   )
-}
-
-PostTemplate.propTypes = {
-  data: PropTypes.shape({
-    mdx: PropTypes.object.isRequired
-  }).isRequired
 }
 
 export const Head = ({ data: { mdx } }) => {

--- a/theme/wrapPageElement.js
+++ b/theme/wrapPageElement.js
@@ -1,13 +1,7 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import Layout from './src/components/layout'
 
 // NOTE(chrisvogt): wraps the page element and sets persistent UI elements
 const wrapPageElement = ({ element, props }) => <Layout {...props}>{element}</Layout>
-
-wrapPageElement.propTypes = {
-  element: PropTypes.node.isRequired,
-  props: PropTypes.object
-}
 
 export default wrapPageElement

--- a/theme/wrapRootElement.js
+++ b/theme/wrapRootElement.js
@@ -3,7 +3,6 @@ import { jsx } from 'theme-ui'
 import { Fragment } from 'react'
 import { Global } from '@emotion/react'
 import { MDXProvider } from '@mdx-js/react'
-import PropTypes from 'prop-types'
 import { Provider as ReduxProvider } from 'react-redux'
 import { ThemeUIProvider } from 'theme-ui'
 
@@ -26,9 +25,5 @@ const wrapRootElement = ({ element }) => (
     </ThemeUIProvider>
   </ReduxProvider>
 )
-
-wrapRootElement.propTypes = {
-  element: PropTypes.node.isRequired
-}
 
 export default wrapRootElement


### PR DESCRIPTION
I've been seeing the alert **Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.** more often in console and unit test logs. Learn more about that in [_Removed: propTypes and defaultProps for functions_](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops)