### PR TITLE
feat: expand the Photography page and add cover art

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -17,7 +17,7 @@ exports[`PostCard matches the snapshot 1`] = `
         className="card-media"
       >
         <div
-          className="css-10hlus8"
+          className="css-19t4del"
         />
       </div>
       <span

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -27,9 +27,12 @@ export default ({ banner, category, date, link, title }) => {
                 sx={{
                   backgroundImage: `url(${banner})`,
                   backgroundPosition: `center`,
-                  backgroundSize: `cover`,
+                  backgroundSize: `contain`,
+                  backgroundRepeat: `no-repeat`,
                   borderRadius: `1px`,
-                  height: `240px`,
+                  // height: `240px`,
+                  width: '100%',
+                  aspectRatio: '1.9 / 1',
                   transition: `all 2.5s ease`
                 }}
               />

--- a/www.chrisvogt.me/content/blog/2019-06-27-nyc-world-pride/2019-06-27-nyc-world-pride.mdx
+++ b/www.chrisvogt.me/content/blog/2019-06-27-nyc-world-pride/2019-06-27-nyc-world-pride.mdx
@@ -1,5 +1,5 @@
 ---
-banner: https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_800,f_auto/v1575433537/photos/2019-nyc-world-pride/IMG_7034
+banner: https://res.cloudinary.com/chrisvogt/image/upload/v1722120138/photos/2019-nyc-world-pride/nyc-pride-banner.jpg
 title: WorldPride NYC 2019
 date: '2019-07-01T09:00:00.000Z'
 category: photography/events

--- a/www.chrisvogt.me/content/blog/2019-12-28-christmas-in-la/2019-12-28-christmas-in-la.mdx
+++ b/www.chrisvogt.me/content/blog/2019-12-28-christmas-in-la/2019-12-28-christmas-in-la.mdx
@@ -1,5 +1,5 @@
 ---
-banner: https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_800,f_auto/v1578376202/photos/2019-christmas-in-la/IMG_3047
+banner: https://res.cloudinary.com/chrisvogt/image/upload/v1722120224/photos/2019-christmas-in-la/la-visit-banner.jpg
 title: Christmas 2019 in Los Angeles
 date: '2019-12-28T21:00:00.000Z'
 category: "photography/events"

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/pages/photography.js
+++ b/www.chrisvogt.me/src/pages/photography.js
@@ -10,8 +10,24 @@ import PageHeader from '../../../theme/src/components/blog/page-header'
 import PostCard from '../../../theme/src/components/widgets/recent-posts/post-card'
 import Seo from '../../../theme/src/components/seo'
 
+const getColumnCount = postsCount => {
+  let columnCount
+  switch (postsCount) {
+    case 1:
+      columnCount = 1
+      break
+    case 2:
+      columnCount = 2
+      break
+    default:
+      columnCount = 3
+  }
+  return columnCount
+}
+
 const PhotographyPage = ({ data }) => {
-const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('photography'))
+  const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('photography'))
+
   return (
     <Layout>
       <Flex
@@ -22,22 +38,25 @@ const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('p
           py: 3
         }}
       >
-        <Container sx={{ flexGrow: 1, width: ['', '', 'max(95ch, 50vw)'] }}>
-          <PageHeader>
-            My Photo Galleries
-          </PageHeader>
+        <Container sx={{ flexGrow: 1, width: ['', '', 'max(95ch, 75vw)'] }}>
+          <PageHeader>My Photo Galleries</PageHeader>
+
+          <Themed.p>
+            These galleries are blog posts with photos and videos I've captured while traveling or at events.
+          </Themed.p>
 
           <Themed.div
             sx={{
               display: `grid`,
               gridAutoRows: `1fr`,
-              gridGap: 4,
-              gridTemplateColumns: `1fr`,
+              gridGap: [3, 3, 4],
+              gridTemplateColumns: [``, `1fr 1fr`, `1fr 1fr`, `1fr 1fr`, `repeat(${getColumnCount(posts.length)}, 1fr)`],
               mt: 4
             }}
           >
             {posts.map(post => (
               <PostCard
+                banner={post.frontmatter.banner}
                 category={post.fields.category?.replace('photography/', '')}
                 date={post.frontmatter.date}
                 excerpt={post.excerpt}
@@ -75,6 +94,7 @@ export const pageQuery = graphql`
             path
           }
           frontmatter {
+            banner
             date(formatString: "MMMM DD, YYYY")
             description
             slug


### PR DESCRIPTION
This PR updates the Photography page to bring cover art to the blog post cards used there. I'd like to do something else with this page... maybe design custom photography banners that have carousels of some of the photos from the post. 🤔 

| Before | After |
|--------|-------|
|    <img width="1628" alt="before" src="https://github.com/user-attachments/assets/ff482b4b-ab6d-4434-9606-b5bec37376cd">    |    <img width="1628" alt="after" src="https://github.com/user-attachments/assets/677eefda-1a0a-4a53-84cd-5076f06baf11">   |
