### PR TITLE
fix: empty Spotify playlists fatally crashing the page

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/spotify/playlists.js
+++ b/theme/src/components/widgets/spotify/playlists.js
@@ -14,6 +14,10 @@ const Playlists = ({ isLoading, playlists = [] }) => {
       tracks: { total: totalTracksCount = 0 } = {}
     } = item
 
+    if (!totalTracksCount) {
+      return null; // Fixes a bug discovered in Prod when an empty album was returned.
+    }
+
     const { url: thumbnailURL } =
       images.find(
         // Spotify provides playlist cover mosaic images at 60, 300 and 640px.
@@ -32,7 +36,7 @@ const Playlists = ({ isLoading, playlists = [] }) => {
       thumbnailURL,
       details: `${name} (${totalTracksCount} tracks)`
     }
-  })
+  }).filter(Boolean)
 
   return (
     <div sx={{ mb: 4 }}>


### PR DESCRIPTION
I woke up to find that my website stopped rendering overnight due to an unhandled exception in the Spotify Playlists widget. A new, unused playlist was being returned by Spotify and my Metrics API and the code expected all playlists to have songs and album artwork.

For now, I've solved that by filtering out playlists without artwork. I'm also trying to delete the playlist on my end in the Spotify UI, but that isn't working. It never truly "deletes" and just gets removed from my library.

| Before | After |
|--------|-------|
|  <img width="1686" alt="Screenshot 2024-07-30 at 7 25 05 AM" src="https://github.com/user-attachments/assets/1ed88404-1bb5-4d14-82b3-c02283040001">     |   <img width="1686" alt="Screenshot 2024-07-30 at 7 25 08 AM" src="https://github.com/user-attachments/assets/dbf5024d-7a4b-49c7-b59c-af894449365a">    |




