### PR TITLE
fix: prevent social icons from render VERY large at first

### DIFF
--- a/theme/src/components/footer/__snapshots__/profiles.spec.js.snap
+++ b/theme/src/components/footer/__snapshots__/profiles.spec.js.snap
@@ -10,7 +10,7 @@ exports[`Profiles matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-github css-4zu0v"
+      className="svg-inline--fa fa-github css-1pinr85"
       data-icon="github"
       data-prefix="fab"
       focusable="false"
@@ -34,7 +34,7 @@ exports[`Profiles matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-instagram css-4zu0v"
+      className="svg-inline--fa fa-instagram css-1pinr85"
       data-icon="instagram"
       data-prefix="fab"
       focusable="false"
@@ -58,7 +58,7 @@ exports[`Profiles matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-linkedin css-4zu0v"
+      className="svg-inline--fa fa-linkedin css-1pinr85"
       data-icon="linkedin"
       data-prefix="fab"
       focusable="false"
@@ -82,7 +82,7 @@ exports[`Profiles matches the snapshot 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="svg-inline--fa fa-x-twitter css-4zu0v"
+      className="svg-inline--fa fa-x-twitter css-1pinr85"
       data-icon="x-twitter"
       data-prefix="fab"
       focusable="false"

--- a/theme/src/components/footer/profiles.js
+++ b/theme/src/components/footer/profiles.js
@@ -52,7 +52,16 @@ export default () => {
           const { displayName, href, slug } = profile
           return (
             <a key={slug} href={href} title={displayName} rel='me' sx={{ mx: [3, 4, 4, 5] }}>
-              <FontAwesomeIcon icon={IconComponent} sx={{ fontSize: [4, 5, 6] }} />
+              <FontAwesomeIcon
+                icon={IconComponent}
+                sx={{
+                  fontSize: [4, 5, 6],
+                  // The following styles are a hack to prevent the icons being too large
+                  // on first render. I imagine there's a better way to do this.
+                  maxHeight: '36px',
+                  maxWidth: '36px'
+                }}
+              />
             </a>
           )
         })}


### PR DESCRIPTION
This PR is a quick fix for the icons rendering way too large on first render.

https://github.com/user-attachments/assets/188d0234-79a9-482b-a387-c9492bb7eaea

