### PR TITLE
fix: add back missing music posts being filtered out

### DIFF
--- a/theme/src/components/category.js
+++ b/theme/src/components/category.js
@@ -3,7 +3,11 @@ import { jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 
 const Category = ({ sx = {}, type }) => {
-  const category = type.replace('photography/travel', 'Travel Photography')
+  const category = type
+    .replace('photography/travel', 'Travel Photography')
+    .replace('photography/events', 'Event Photography')
+    .replace('music/piano-covers', 'Piano Covers')
+
   return (
     <Themed.div sx={{ variant: `text.title`, fontSize: [1], ...sx }}>
       {category}

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -16,7 +16,7 @@ const getDescription = mdx => mdx.frontmatter.description
 const getTitle = mdx => mdx.frontmatter.title
 
 const MediaTemplate = ({ data: { mdx }, children }) => {
-  const category = mdx.fields.category?.replace('Photography/', '')
+  const category = mdx.fields.category?.replace('photography/', '').replace('music/', '')
   const date = mdx.frontmatter.date
   const soundcloudId = mdx.frontmatter.soundcloudId
   const title = getTitle(mdx)

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -16,7 +16,7 @@ const getDescription = mdx => mdx.frontmatter.description
 const getTitle = mdx => mdx.frontmatter.title
 
 const MediaTemplate = ({ data: { mdx }, children }) => {
-  const category = mdx.fields.category?.replace('photography/', '').replace('music/', '')
+  const category = mdx.fields.category
   const date = mdx.frontmatter.date
   const soundcloudId = mdx.frontmatter.soundcloudId
   const title = getTitle(mdx)

--- a/www.chrisvogt.me/src/pages/music.js
+++ b/www.chrisvogt.me/src/pages/music.js
@@ -11,7 +11,7 @@ import PostCard from '../../../theme/src/components/widgets/recent-posts/post-ca
 import Seo from '../../../theme/src/components/seo'
 
 const MusicPage = ({ data }) => {
-  const posts = getPosts(data)?.filter(post => post.fields.category === 'music')
+  const posts = getPosts(data)?.filter(post => post.fields.category?.startsWith('music'))
   return (
     <Layout>
       <Flex

--- a/www.chrisvogt.me/src/pages/music.js
+++ b/www.chrisvogt.me/src/pages/music.js
@@ -38,7 +38,7 @@ const MusicPage = ({ data }) => {
           >
             {posts.map(post => (
               <PostCard
-                category={post.fields.category}
+                category={post.fields.category?.replace('music/', '')}
                 date={post.frontmatter.date}
                 key={post.fields.id}
                 link={post.fields.path}

--- a/www.chrisvogt.me/src/pages/music.js
+++ b/www.chrisvogt.me/src/pages/music.js
@@ -38,7 +38,7 @@ const MusicPage = ({ data }) => {
           >
             {posts.map(post => (
               <PostCard
-                category={post.fields.category?.replace('music/', '')}
+                category={post.fields.category}
                 date={post.frontmatter.date}
                 key={post.fields.id}
                 link={post.fields.path}

--- a/www.chrisvogt.me/src/pages/photography.js
+++ b/www.chrisvogt.me/src/pages/photography.js
@@ -57,7 +57,7 @@ const PhotographyPage = ({ data }) => {
             {posts.map(post => (
               <PostCard
                 banner={post.frontmatter.banner}
-                category={post.fields.category?.replace('photography/', '')}
+                category={post.fields.category}
                 date={post.frontmatter.date}
                 key={post.fields.id}
                 link={post.fields.path}


### PR DESCRIPTION
I noticed some of my music posts, like https://www.chrisvogt.me/music/piano-covers/here-there-everywhere/, are being filtered out of the page because they are nested categories (with a `/` in the category name). This PR fixes that.