### PR TITLE
fix: warnings about ThemeProvider rename and deprecation

### DIFF
--- a/theme/src/components/button.spec.js
+++ b/theme/src/components/button.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Button from './button'
-import { ThemeProvider } from 'theme-ui'
+import { ThemeUIProvider } from 'theme-ui'
 
 // Mock Theme
 const mockTheme = {
@@ -19,7 +19,7 @@ const mockTheme = {
 }
 
 // Helper function to render with theme
-const renderWithTheme = component => render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>)
+const renderWithTheme = component => render(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>)
 
 describe('Button', () => {
   it('renders a button with default variant (primary)', () => {

--- a/theme/src/components/footer/footer.spec.js
+++ b/theme/src/components/footer/footer.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Footer from './footer'
-import { ThemeProvider } from 'theme-ui'
+import { ThemeUIProvider } from 'theme-ui'
 import useSiteMetadata from '../../hooks/use-site-metadata' // Ensure correct import
 import { getFooterText } from '../../selectors/metadata'
 
@@ -28,7 +28,7 @@ const mockTheme = {
 }
 
 // Helper function to render with theme
-const renderWithTheme = component => render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>)
+const renderWithTheme = component => render(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>)
 
 describe('Footer', () => {
   beforeEach(() => {

--- a/theme/src/components/widgets/goodreads/user-profile.spec.js
+++ b/theme/src/components/widgets/goodreads/user-profile.spec.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { ThemeProvider } from 'theme-ui'
+import { ThemeUIProvider } from 'theme-ui'
 import UserProfile from './user-profile'
 import { useThemeUI } from 'theme-ui'
 import MetricCard from '../metric-card'
@@ -33,8 +33,8 @@ const mockTheme = {
   }
 }
 
-// Helper function to wrap in ThemeProvider
-const renderWithTheme = ui => render(<ThemeProvider theme={mockTheme}>{ui}</ThemeProvider>)
+// Helper function to wrap in ThemeUIProvider
+const renderWithTheme = ui => render(<ThemeUIProvider theme={mockTheme}>{ui}</ThemeUIProvider>)
 
 describe('UserProfile', () => {
   const profileData = {

--- a/theme/src/pages/404.spec.js
+++ b/theme/src/pages/404.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import NotFoundPage from './404';
-import { ThemeProvider } from 'theme-ui';
+import { ThemeUIProvider } from 'theme-ui';
 
 // Mock Layout component
 jest.mock('../components/layout', () => ({ children }) => (
@@ -23,7 +23,7 @@ const mockTheme = {
 
 // Helper function to render with theme
 const renderWithTheme = (component) =>
-  render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>);
+  render(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>);
 
 describe('404 Page', () => {
   it('renders correctly', () => {

--- a/theme/src/templates/home.spec.js
+++ b/theme/src/templates/home.spec.js
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import HomeTemplate, { Head } from './home'
 import { useStaticQuery } from 'gatsby'
-import { ThemeProvider } from 'theme-ui'
+import { ThemeUIProvider } from 'theme-ui'
 
 // Mock components
 jest.mock('../components/footer', () => () => <footer>Footer</footer>)
@@ -46,7 +46,7 @@ const mockTheme = {
 }
 
 // Helper function to render with theme
-const renderWithTheme = component => render(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>)
+const renderWithTheme = component => render(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>)
 
 describe('HomeTemplate', () => {
   it('renders correctly with given data', () => {

--- a/theme/src/templates/media.spec.js
+++ b/theme/src/templates/media.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { ThemeProvider } from 'theme-ui'
+import { ThemeUIProvider } from 'theme-ui'
 import { useStaticQuery } from 'gatsby'
 
 import Media, { Head } from './media'
@@ -57,9 +57,9 @@ describe('Media Post', () => {
     jest.clearAllMocks()
   })
 
-  // Helper function to wrap components in the ThemeProvider
+  // Helper function to wrap components in the ThemeUIProvider
   const renderWithTheme = (component) =>
-    renderer.create(<ThemeProvider theme={mockTheme}>{component}</ThemeProvider>)
+    renderer.create(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>)
 
   // Test with no media sources
   it('renders correctly with no media sources', () => {


### PR DESCRIPTION
This PR resolves a warnings that's been logging about [ThemeProvider being renamed to ThemeUIProvider](https://github.com/system-ui/theme-ui/pull/2360).