### PR TITLE
chore: extend (2x) Lighthouse GH Action timeout

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,7 +11,7 @@ jobs:
         id: netlify
         with:
           site_name: 'chrisvogt'
-          max_timeout: 120
+          max_timeout: 240
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v10
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -11,7 +11,7 @@ jobs:
         id: netlify
         with:
           site_name: 'chrisvogt'
-          max_timeout: 240
+          max_timeout: 600 // # Timeout if the deploy preview hasn't posted within 10 minutes
       - name: Audit URLs using Lighthouse
         uses: treosh/lighthouse-ci-action@v10
         with:


### PR DESCRIPTION
This specific GitHub Action keeps timing out waiting for the Netlify deploy preview to generate. This doubles that timeout value in an attempt to mitigate or resolve that.