### PR TITLE
fix: uncaught exception due to undefined Spotify playlist

### DIFF
--- a/theme/src/components/widgets/spotify/playlists.js
+++ b/theme/src/components/widgets/spotify/playlists.js
@@ -6,6 +6,11 @@ import { Themed } from '@theme-ui/mdx'
 
 const Playlists = ({ isLoading, playlists = [] }) => {
   const items = playlists.map(item => {
+    if (!item) {
+      // Added 11/28/24 to fix a bug where an empty playlist was being returned
+      return;
+    }
+
     const {
       external_urls: { spotify: spotifyURL } = {},
       id,


### PR DESCRIPTION
My production site has gone down 😱 and is rendering a blank page in Prod, and an exception in Development.

<img width="1766" alt="Screenshot 2024-11-28 at 11 32 21 AM" src="https://github.com/user-attachments/assets/7e2ec083-e7ff-432b-89c0-008f911bad5b">

<img width="1766" alt="Screenshot 2024-11-28 at 11 30 29 AM" src="https://github.com/user-attachments/assets/228a35f4-8eef-44b3-ab03-42ee0eac0095">
