### PR TITLE
feat: reverse Spotify widget content – Top Tracks 1st

### DIFF
--- a/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
@@ -2,9 +2,7 @@
 
 exports[`Playlists Component matches the snapshot 1`] = `
 <DocumentFragment>
-  <div
-    class="css-16ilj6a"
-  >
+  <div>
     <div
       class="css-ccroti"
     >

--- a/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
@@ -188,13 +188,13 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
       <h3
         className="css-9nh3l5"
       >
-        Playlists
+        Top Tracks
       </h3>
     </div>
     <p
       className="css-1qwovgy"
     >
-      My 12 favorite playlists.
+      My 12 most-played tracks over the last 4 weeks.
     </p>
     <div
       className="media-item_grid null css-5stlgz"
@@ -388,13 +388,13 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
       <h3
         className="css-9nh3l5"
       >
-        Top Tracks
+        Playlists
       </h3>
     </div>
     <p
       className="css-1qwovgy"
     >
-      My 12 most-played tracks over the last 4 weeks.
+      My 12 favorite playlists.
     </p>
     <div
       className="media-item_grid null css-5stlgz"

--- a/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TopTracks Component handles tracks without a 300px image gracefully 1`] = `
-<div>
+<div
+  className="css-16ilj6a"
+>
   <div
     className="css-ccroti"
   >
@@ -38,7 +40,9 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
 `;
 
 exports[`TopTracks Component renders correctly when loading 1`] = `
-<div>
+<div
+  className="css-16ilj6a"
+>
   <div
     className="css-ccroti"
   >
@@ -241,7 +245,9 @@ exports[`TopTracks Component renders correctly when loading 1`] = `
 `;
 
 exports[`TopTracks Component renders correctly with no tracks 1`] = `
-<div>
+<div
+  className="css-16ilj6a"
+>
   <div
     className="css-ccroti"
   >
@@ -263,7 +269,9 @@ exports[`TopTracks Component renders correctly with no tracks 1`] = `
 `;
 
 exports[`TopTracks Component renders correctly with tracks 1`] = `
-<div>
+<div
+  className="css-16ilj6a"
+>
   <div
     className="css-ccroti"
   >

--- a/theme/src/components/widgets/spotify/playlists.js
+++ b/theme/src/components/widgets/spotify/playlists.js
@@ -46,7 +46,7 @@ const Playlists = ({ isLoading, playlists = [] }) => {
     .filter(Boolean)
 
   return (
-    <div sx={{ mb: 4 }}>
+    <div>
       <div sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>
           Playlists

--- a/theme/src/components/widgets/spotify/spotify-widget.js
+++ b/theme/src/components/widgets/spotify/spotify-widget.js
@@ -60,8 +60,9 @@ const SpotifyWidget = () => {
       </WidgetHeader>
 
       <ProfileMetricsBadge isLoading={isLoading} metrics={metrics} />
-      <Playlists isLoading={isLoading} playlists={playlists} />
+
       <TopTracks isLoading={isLoading} tracks={topTracks} />
+      <Playlists isLoading={isLoading} playlists={playlists} />
     </Widget>
   )
 }

--- a/theme/src/components/widgets/spotify/top-tracks.js
+++ b/theme/src/components/widgets/spotify/top-tracks.js
@@ -22,7 +22,7 @@ const TopTracks = ({ isLoading, tracks = [] }) => {
   })
 
   return (
-    <div>
+    <div sx={{ mb: 4 }}>
       <div sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>
           Top Tracks


### PR DESCRIPTION
This PR flips the Spotify widget so that Top Tracks renders before Playlists.

<img width="1759" alt="Screenshot 2024-12-02 at 9 58 56 PM" src="https://github.com/user-attachments/assets/e6a5bd33-16d6-4860-9b2c-c8c9fcf29c11">
