### PR TITLE
fix: cap maximum playlists at 12 items

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/playlists.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Playlists Component matches the snapshot 1`] = `
+exports[`Playlists Component matches snapshot with various playlist scenarios 1`] = `
 <DocumentFragment>
   <div>
     <div

--- a/theme/src/components/widgets/spotify/playlists.js
+++ b/theme/src/components/widgets/spotify/playlists.js
@@ -20,8 +20,11 @@ const Playlists = ({ isLoading, playlists = [] }) => {
         tracks: { total: totalTracksCount = 0 } = {}
       } = item
 
-      if (!totalTracksCount) {
-        return null // Fixes a bug discovered in Prod when an empty album was returned.
+      // Skip playlist for the following reasons:
+      // undefined totalTracksCount: Fixes a bug discovered in Prod when an empty album was returned.
+      // undefined images: Fixes a bug and since these playlists are image-centric, we don't want to render them without an image.
+      if (!(totalTracksCount && images.length)) {
+        return null
       }
 
       const { url: thumbnailURL } =
@@ -44,6 +47,7 @@ const Playlists = ({ isLoading, playlists = [] }) => {
       }
     })
     .filter(Boolean)
+    .slice(0, 12) // Limit to 12 playlists for now. As of December 2024 the API response includes > 12 playlists.
 
   return (
     <div>

--- a/theme/src/components/widgets/spotify/playlists.spec.js
+++ b/theme/src/components/widgets/spotify/playlists.spec.js
@@ -22,7 +22,7 @@ describe('Playlists Component', () => {
           tracks: { total: totalTracksCount = 0 } = {}
         } = item
 
-        if (!totalTracksCount) {
+        if (!totalTracksCount || images.length === 0) {
           return null
         }
 
@@ -37,6 +37,7 @@ describe('Playlists Component', () => {
         }
       })
       .filter(Boolean)
+      .slice(0, 12)
 
     const { getByTestId } = render(<Playlists isLoading={false} playlists={playlists} />)
 
@@ -53,8 +54,123 @@ describe('Playlists Component', () => {
     expect(getByTestId('media-item-grid')).toBeInTheDocument()
   })
 
-  it('matches the snapshot', () => {
-    const { asFragment } = render(<Playlists isLoading={false} playlists={playlists} />)
+  it('limits playlists to 12 items', () => {
+    const playlistsWithMoreThan12Items = Array(15)
+      .fill(null)
+      .map((_, index) => ({
+        external_urls: { spotify: `https://open.spotify.com/playlist/${index}` },
+        id: `playlist-${index}`,
+        images: [{ url: `https://image.url/${index}.jpg`, width: 300 }],
+        name: `Playlist ${index}`,
+        tracks: { total: 10 }
+      }))
+
+    render(<Playlists isLoading={false} playlists={playlistsWithMoreThan12Items} />)
+
+    expect(MediaItemGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: playlistsWithMoreThan12Items.slice(0, 12).map(playlist => ({
+          id: playlist.id,
+          name: playlist.name,
+          spotifyURL: playlist.external_urls.spotify,
+          thumbnailURL: playlist.images[0].url,
+          details: `${playlist.name} (10 tracks)`
+        }))
+      }),
+      {}
+    )
+  })
+
+  it('skips invalid playlists', () => {
+    const invalidPlaylists = [
+      null,
+      { id: 'invalid-1' },
+      {
+        id: 'invalid-2',
+        tracks: { total: 0 },
+        images: []
+      }
+    ]
+
+    render(<Playlists isLoading={false} playlists={invalidPlaylists} />)
+
+    expect(MediaItemGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [] // No valid playlists should be passed to MediaItemGrid
+      }),
+      {}
+    )
+  })
+
+  it('passes isLoading prop to MediaItemGrid', () => {
+    render(<Playlists isLoading={true} playlists={[]} />)
+
+    expect(MediaItemGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isLoading: true, // We're only asserting for the isLoading prop
+        items: [] // And that the items array is empty as expected
+      }),
+      expect.anything() // Ensures we're not overly specific about other props
+    )
+  })
+
+  it('handles an empty playlists array', () => {
+    render(<Playlists isLoading={false} playlists={[]} />)
+
+    expect(MediaItemGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [] // No playlists should be passed
+      }),
+      {}
+    )
+  })
+
+  it('handles playlists with no images or tracks', () => {
+    const playlistsWithMissingData = [
+      {
+        id: 'no-images',
+        external_urls: { spotify: 'https://spotify.com/no-images' },
+        images: [],
+        name: 'No Images Playlist',
+        tracks: { total: 5 }
+      },
+      {
+        id: 'no-tracks',
+        external_urls: { spotify: 'https://spotify.com/no-tracks' },
+        images: [{ url: 'https://image.url/no-tracks.jpg', width: 300 }],
+        name: 'No Tracks Playlist',
+        tracks: { total: 0 }
+      }
+    ]
+
+    render(<Playlists isLoading={false} playlists={playlistsWithMissingData} />)
+
+    expect(MediaItemGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [] // Neither playlist should be passed
+      }),
+      {}
+    )
+  })
+
+  it('matches snapshot with various playlist scenarios', () => {
+    const variedPlaylists = [
+      {
+        id: 'valid',
+        external_urls: { spotify: 'https://spotify.com/valid' },
+        images: [{ url: 'https://image.url/valid.jpg', width: 300 }],
+        name: 'Valid Playlist',
+        tracks: { total: 10 }
+      },
+      null,
+      {
+        id: 'invalid',
+        images: [],
+        tracks: { total: 0 }
+      }
+    ]
+
+    const { asFragment } = render(<Playlists isLoading={false} playlists={variedPlaylists} />)
     expect(asFragment()).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
I recently updated the backing service behind my dashboard page to return > 12 playlists. This PR caps the items rendered to match what the UI expects.