### PR TITLE
chore: iterate on the light mode background styles

### DIFF
--- a/theme/src/components/__snapshots__/layout.spec.js.snap
+++ b/theme/src/components/__snapshots__/layout.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layout matches the snapshot 1`] = `
 <div
-  className="css-1m13iln"
+  className="css-9941j0"
 >
   <div
     style={
@@ -30,9 +30,9 @@ exports[`Layout matches the snapshot 1`] = `
     <div
       style={
         {
-          "WebkitBackdropFilter": "blur(100px)",
-          "backdropFilter": "blur(100px)",
-          "backgroundColor": "rgba(75, 0, 130, 0.02)",
+          "WebkitBackdropFilter": "blur(75px)",
+          "backdropFilter": "blur(75px)",
+          "backgroundColor": "rgba(253, 248, 245, 0.15)",
           "height": "100%",
           "left": 0,
           "pointerEvents": "none",

--- a/theme/src/components/animated-background.js
+++ b/theme/src/components/animated-background.js
@@ -1,11 +1,14 @@
-/*!
- * Animated Background
- * (c) 2024 Christopher Vogt
- * This code is licensed under the MIT License.
- * Created with the assistance of ChatGPT by OpenAI.
- */
-
 import React, { useEffect, useRef } from 'react'
+import { useColorMode, useThemeUI } from 'theme-ui'
+
+// Helper function to convert hex to rgba
+const hexToRgba = (hex, alpha = 1) => {
+  const [r, g, b] = hex
+    .replace(/^#/, '')
+    .match(/.{2}/g)
+    .map(x => parseInt(x, 16))
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
 
 class Circle {
   constructor(x, y, radius, gradientStops) {
@@ -20,18 +23,18 @@ class Circle {
   draw(ctx) {
     if (!ctx) return
 
-    ctx.globalAlpha = 0.45 // Set transparency to 45%
     const gradient = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, this.radius)
     this.gradientStops.forEach(stop => {
       gradient.addColorStop(stop.position, stop.color)
     })
 
+    ctx.globalAlpha = 0.5 // Balanced opacity
     ctx.beginPath()
     ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2)
     ctx.fillStyle = gradient
     ctx.fill()
     ctx.closePath()
-    ctx.globalAlpha = 1.0 // Reset transparency to 100%
+    ctx.globalAlpha = 1.0 // Reset transparency
   }
 
   update(canvas, ctx) {
@@ -56,6 +59,10 @@ export { Circle }
 
 const AnimatedBackground = () => {
   const canvasRef = useRef(null)
+  const [colorMode] = useColorMode()
+  const { theme } = useThemeUI()
+  const backgroundHex = theme.rawColors?.background || '#1e1e2f' // Default to fallback color
+  const backgroundRgba = hexToRgba(backgroundHex, 0.15) // Apply transparency to background color
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -71,7 +78,7 @@ const AnimatedBackground = () => {
 
     setCanvasSize()
 
-    const gradients = [
+    const darkModeGradients = [
       [
         { position: 0, color: 'rgba(128, 0, 128, 1)' }, // Royal Purple
         { position: 0.2, color: 'rgba(128, 0, 128, 0.9)' },
@@ -89,6 +96,21 @@ const AnimatedBackground = () => {
         { position: 1, color: 'rgba(128, 0, 128, 0.5)' }
       ]
     ]
+
+    const lightModeGradients = [
+      [
+        { position: 0, color: 'rgba(66, 46, 163, 1)' }, // Primary Purple
+        { position: 0.4, color: 'rgba(255, 20, 147, 0.8)' }, // Hot Pink
+        { position: 1, color: 'rgba(30, 144, 255, 0.6)' } // Vibrant Blue
+      ],
+      [
+        { position: 0, color: 'rgba(255, 20, 147, 1)' }, // Hot Pink
+        { position: 0.5, color: 'rgba(30, 144, 255, 0.8)' }, // Vibrant Blue
+        { position: 1, color: 'rgba(255, 235, 200, 0.5)' } // Pale Peach
+      ]
+    ]
+
+    const gradients = colorMode === 'dark' ? darkModeGradients : lightModeGradients
 
     const circles = []
 
@@ -123,14 +145,21 @@ const AnimatedBackground = () => {
     return () => {
       window.removeEventListener('resize', handleResize)
     }
-  }, [])
+  }, [colorMode])
 
   return (
     <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
       <canvas
         ref={canvasRef}
-        style={{ display: 'block', position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
-      ></canvas>
+        style={{
+          display: 'block',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%'
+        }}
+      />
       <div
         style={{
           position: 'absolute',
@@ -138,9 +167,9 @@ const AnimatedBackground = () => {
           left: 0,
           width: '100%',
           height: '100%',
-          backgroundColor: 'rgba(75, 0, 130, 0.02)',
-          backdropFilter: 'blur(100px)',
-          WebkitBackdropFilter: 'blur(100px)', // Safari
+          backgroundColor: backgroundRgba, // Unified background color with transparency
+          backdropFilter: 'blur(75px)',
+          WebkitBackdropFilter: 'blur(75px)', // Safari
           pointerEvents: 'none' // Ensure the overlay doesn't block interactions
         }}
       ></div>

--- a/theme/src/components/layout.spec.js
+++ b/theme/src/components/layout.spec.js
@@ -1,27 +1,47 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
+import { ThemeProvider } from 'theme-ui'
 
 import Footer from './footer'
 import Layout from './layout'
 import TopNavigation from './top-navigation'
 
+// Mock Footer and TopNavigation components
 jest.mock('./footer')
 jest.mock('./top-navigation')
 
 describe('Layout', () => {
   TopNavigation.mockImplementation(() => <div className='MOCK__TopNavigation'></div>)
   Footer.mockImplementation(() => <div className='MOCK__Footer'></div>)
+
+  // Mock theme
+  const mockTheme = {
+    colors: {
+      background: '#fdf8f5',
+      text: '#111',
+      modes: {
+        dark: {
+          background: '#1e1e2f',
+          text: '#fff'
+        }
+      }
+    }
+  }
+
   it('matches the snapshot', () => {
     const tree = renderer
       .create(
-        <Layout>
-          <div className='fake-website'>
-            <h1>Fake Website</h1>
-            <p>Lorum ipsum dolor sit amet.</p>
-          </div>
-        </Layout>
+        <ThemeProvider theme={mockTheme}>
+          <Layout>
+            <div className='fake-website'>
+              <h1>Fake Website</h1>
+              <p>Lorum ipsum dolor sit amet.</p>
+            </div>
+          </Layout>
+        </ThemeProvider>
       )
       .toJSON()
+
     expect(tree).toMatchSnapshot()
   })
 })

--- a/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
+++ b/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
@@ -167,7 +167,7 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
   },
   "colors": {
     "accent": "deeppink",
-    "background": "#fcb8a2",
+    "background": "#fdf8f5",
     "modes": {
       "dark": {
         "background": "#1e1e2f",

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -188,7 +188,7 @@ export default merge(tailwind, {
 
   colors: {
     accent: 'deeppink',
-    background: '#fcb8a2',
+    background: '#fdf8f5',
     'panel-background': 'rgba(255, 229, 224, 0.10)',
     'panel-divider': () => '1px solid rgba(255, 229, 224, 0.17)',
     'panel-highlight': theme => theme.colors.gray[1],

--- a/theme/src/gatsby-plugin-theme-ui/theme.spec.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.spec.js
@@ -121,7 +121,7 @@ describe('Theme Configuration', () => {
 
   describe('color mode configurations', () => {
     it('defines light mode background colors', () => {
-      expect(theme.colors.background).toBe('#fcb8a2')
+      expect(theme.colors.background).toBe('#fdf8f5')
       expect(theme.colors['panel-background']).toContain('rgba(255, 229, 224, 0.10)')
     })
 


### PR DESCRIPTION
This PR iterates on the light mode background styles and replaces the peach with an off-white color.

### Before

<img width="1637" alt="Screenshot 2024-12-07 at 12 13 58 PM" src="https://github.com/user-attachments/assets/0f6016a9-26e1-419a-b818-bba7154eac71">

### After

<img width="1637" alt="Screenshot 2024-12-07 at 12 13 52 PM" src="https://github.com/user-attachments/assets/0cfb59c9-5eb9-4219-a25e-430c1e5d230d">
