### PR TITLE
feat: switch to initial color mode to prevent flash

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
+++ b/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
@@ -191,7 +191,8 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
   },
   "config": {
     "printColorModeName": "default",
-    "useColorSchemeMediaQuery": "system",
+    "useColorSchemeMediaQuery": "initial",
+    "useCustomProperties": true,
     "useLocalStorage": true,
   },
   "fontSizes": [

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -108,7 +108,8 @@ export const PostCard = {
 export default merge(tailwind, {
   config: {
     useLocalStorage: true, // Persist user preferences
-    useColorSchemeMediaQuery: 'system', // Disable automatic detection of system preference
+    useCustomProperties: true,
+    useColorSchemeMediaQuery: 'initial', // Disable automatic detection of system preference
     printColorModeName: 'default'
   },
 

--- a/theme/src/gatsby-plugin-theme-ui/theme.spec.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.spec.js
@@ -20,8 +20,9 @@ describe('Theme Configuration', () => {
     })
 
     it('defaults the color mode to dark', () => {
-      expect(theme.config.useColorSchemeMediaQuery).toBe('system')
-      expect(theme.config).toHaveProperty('useLocalStorage')
+      expect(theme.config.useColorSchemeMediaQuery).toBe('initial')
+      expect(theme.config.useCustomProperties).toBe(true)
+      expect(theme.config.useLocalStorage).toBe(true)
     })
   })
 


### PR DESCRIPTION
This PR sets the color mode to "initial" to prevent a flash of content I'm seeing when it's set to 'system'.