### PR TITLE
feat: disable download for instagram lightbox views

### DIFF
--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -149,6 +149,7 @@ export default () => {
         }}
         plugins={[lgThumbnail, lgZoom, lgVideo, lgAutoplay]}
         licenseKey={process.env.GATSBY_LIGHT_GALLERY_LICENSE_KEY}
+        download={false}
         dynamic
         dynamicEl={media.map(post => ({
           thumb: post.cdnMediaURL,


### PR DESCRIPTION
Disables the download button for Instagram since it's not really meant for that.