### PR TITLE
feat: modernize Husky to factor out deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md,mdx}\"",
     "lint": "eslint",
     "postinstall": "node index.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "prettier": "prettier",
     "test:coverage": "yarn workspace gatsby-theme-chrisvogt test --coverage",
     "test:watch": "yarn workspace gatsby-theme-chrisvogt test:watch",
@@ -27,7 +27,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.2",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "husky": "^9.0.11",
+    "husky": "^9.1.7",
     "lint-staged": "^15.2.10",
     "prettier": "^3.4.1",
     "pretty-quick": "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8583,7 +8583,7 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-husky@^9.0.11:
+husky@^9.0.11, husky@^9.1.7:
   version "9.1.7"
   resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
   integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==


### PR DESCRIPTION
I keep seeing this log into the browser:

```sh
[4/4] 🔨  Building fresh packages...
$ node index.js
┌───────────────────────────────────┐
│                                   │
│         www.chrisvogt.me          │
│        My Personal Website        │
│                                   │
└───────────────────────────────────┘
✅  Installation succeeded: gatsby-theme-chrisvogt
⚙  Version: 0.33.0
$ husky install
husky - install command is DEPRECATED
✨  Done in 2.44s.
```

The [_Husky v9.0.1 Release Notes_](https://github.com/typicode/husky/releases/tag/v9.0.1) include a How to Migrate section that explains the changes made here.