### PR TITLE
fix: (v0.33.3) updated Goodreads status update rendering NaN

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.33.2",
+  "version": "0.33.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/goodreads/user-status.js
+++ b/theme/src/components/widgets/goodreads/user-status.js
@@ -23,7 +23,7 @@ const mapStatusToTemplate = {
 }
 
 const UserStatus = ({ isLoading, status, actorName }) => {
-  const { created, link, type } = status
+  const { created, link, type, updated } = status
 
   const statusText = mapStatusToTemplate[type] ? mapStatusToTemplate[type](status) : 'Loading...'
 
@@ -67,7 +67,7 @@ const UserStatus = ({ isLoading, status, actorName }) => {
               ready={!isLoading}
               showLoadingAnimation
             >
-              <span>Posted {ago(new Date(created))}</span>
+              <span>Posted {ago(new Date(created || updated))}</span>
               <ViewExternal platform='Goodreads' />
             </Placeholder>
           </CardFooter>


### PR DESCRIPTION
This PR fixes an issue where the Goodreads widget is rendering "NaN" for a recent status update that is missing the "created" field from the Goodreads API response, but does have an "updated" field. I do remember updating the status to status after the original review.

<img width="930" alt="Screenshot 2024-12-30 at 10 32 19 PM" src="https://github.com/user-attachments/assets/313c186a-cc26-448e-981c-4a6bce06b2a0" />

### Screenshot: before this change

<img width="1713" alt="Screenshot 2024-12-30 at 10 34 53 PM" src="https://github.com/user-attachments/assets/ba589444-fe9f-4b50-9c24-c184517055d2" />

### Screenshot: after this change

<img width="1713" alt="Screenshot 2024-12-30 at 10 34 34 PM" src="https://github.com/user-attachments/assets/d06e8910-7487-45cc-9f18-2011cbbbf7d6" />
