### PR TITLE
feat: replace tilt effect during Instagram media interactions

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.33.3",
+  "version": "0.34.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",
@@ -105,7 +105,6 @@
     "redux": "^5.0.1",
     "s-ago": "^2.2.0",
     "svg-loaders-react": "^3.0.1",
-    "theme-ui": "^0.16.2",
-    "vanilla-tilt": "^1.8.1"
+    "theme-ui": "^0.16.2"
   }
 }

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`InstagramWidgetItem matches the snapshot 1`] = `
 <DocumentFragment>
   <button
-    class="instagram-item-button css-1u8qly9"
+    class="instagram-item-button media-item_media css-1u8qly9"
     rel="noopener noreferrer"
   >
     <img

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -11,7 +11,7 @@ const InstagramWidgetItem = ({
   onBlur = () => {},
   onMouseEnter = () => {},
   onMouseLeave = () => {},
-  post: { caption, cdnMediaURL, id, mediaType } = {}
+  post: { caption, cdnMediaURL = '', id, mediaType } = {}
 }) => {
   const isCarousel = mediaType === 'CAROUSEL_ALBUM'
   const isVideo = mediaType === 'VIDEO'

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -3,7 +3,16 @@ import { jsx } from 'theme-ui'
 import { faImages, faVideo } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
-const InstagramWidgetItem = ({ handleClick, index, post: { caption, cdnMediaURL, id, mediaType } = {} }) => {
+const InstagramWidgetItem = ({
+  isFocusedItem,
+  handleClick,
+  index,
+  onFocus = () => {},
+  onBlur = () => {},
+  onMouseEnter = () => {},
+  onMouseLeave = () => {},
+  post: { caption, cdnMediaURL, id, mediaType } = {}
+}) => {
   const isCarousel = mediaType === 'CAROUSEL_ALBUM'
   const isVideo = mediaType === 'VIDEO'
 
@@ -12,19 +21,25 @@ const InstagramWidgetItem = ({ handleClick, index, post: { caption, cdnMediaURL,
       key={id}
       onClick={event => handleClick(event, { index, photo: { caption, id, src: cdnMediaURL } })}
       rel='noopener noreferrer'
-      className='instagram-item-button'
+      className={`instagram-item-button media-item_media${isFocusedItem ? ' media-item--focused' : ''}`}
+      onBlur={onBlur}
+      onFocus={onFocus}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       sx={{
         variant: 'styles.InstagramItem'
       }}
     >
       {(isCarousel || isVideo) && (
         <div
+          className='media-item_icon'
           data-testid={isVideo ? 'video-icon' : 'carousel-icon'}
           sx={{
             color: 'white',
             position: 'absolute',
             top: 2,
-            right: 2
+            right: 2,
+            opacity: 0
           }}
         >
           <FontAwesomeIcon icon={isVideo ? faVideo : faImages} />

--- a/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
@@ -93,4 +93,71 @@ describe('InstagramWidgetItem', () => {
     expect(carouselIcon).not.toBeInTheDocument()
     expect(videoIcon).not.toBeInTheDocument()
   })
+
+  it('does not display any icon for unknown mediaType', () => {
+    const unknownMediaTypeProps = {
+      ...defaultProps,
+      post: {
+        ...defaultProps.post,
+        mediaType: 'UNKNOWN_TYPE'
+      }
+    }
+
+    render(<InstagramWidgetItem {...unknownMediaTypeProps} />)
+
+    const carouselIcon = screen.queryByTestId('carousel-icon')
+    const videoIcon = screen.queryByTestId('video-icon')
+    expect(carouselIcon).not.toBeInTheDocument()
+    expect(videoIcon).not.toBeInTheDocument()
+  })
+
+  it('renders correctly when caption is missing', () => {
+    const noCaptionProps = {
+      ...defaultProps,
+      post: {
+        ...defaultProps.post,
+        caption: undefined
+      }
+    }
+
+    render(<InstagramWidgetItem {...noCaptionProps} />)
+
+    const img = screen.getByAltText('Instagram post thumbnail')
+    expect(img).toBeInTheDocument()
+  })
+
+  it('renders correctly when cdnMediaURL is missing', () => {
+    const noCdnMediaURLProps = {
+      ...defaultProps,
+      post: {
+        ...defaultProps.post,
+        cdnMediaURL: undefined
+      }
+    }
+
+    render(<InstagramWidgetItem {...noCdnMediaURLProps} />)
+
+    const img = screen.getByAltText('Instagram post thumbnail')
+    expect(img).toHaveAttribute('src', '?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format')
+  })
+
+  it('calls onFocus when the button gains focus', () => {
+    const mockOnFocus = jest.fn()
+    render(<InstagramWidgetItem {...defaultProps} onFocus={mockOnFocus} />)
+
+    const button = screen.getByRole('button')
+    fireEvent.focus(button)
+
+    expect(mockOnFocus).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onBlur when the button loses focus', () => {
+    const mockOnBlur = jest.fn()
+    render(<InstagramWidgetItem {...defaultProps} onBlur={mockOnBlur} />)
+
+    const button = screen.getByRole('button')
+    fireEvent.blur(button)
+
+    expect(mockOnBlur).toHaveBeenCalledTimes(1)
+  })
 })

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -5,13 +5,13 @@ import { Grid } from '@theme-ui/components'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useCallback, useState, useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import classnames from 'classnames'
 import lgAutoplay from 'lightgallery/plugins/autoplay'
 import lgThumbnail from 'lightgallery/plugins/thumbnail'
 import lgVideo from 'lightgallery/plugins/video'
 import lgZoom from 'lightgallery/plugins/zoom'
 import LightGallery from 'lightgallery/react'
 import ReactPlaceholder from 'react-placeholder'
-import VanillaTilt from 'vanilla-tilt'
 
 import 'lightgallery/css/lightgallery.css'
 import 'lightgallery/css/lg-thumbnail.css'
@@ -53,7 +53,9 @@ export default () => {
   const media = useSelector(getMedia)
   const metrics = useSelector(getMetrics)
 
+  const [focusedItem, setFocusedItem] = useState(null)
   const [isShowingMore, setIsShowingMore] = useState(false)
+
   const lightGalleryRef = useRef(null)
 
   useEffect(() => {
@@ -61,18 +63,6 @@ export default () => {
       dispatch(fetchDataSource('instagram', instagramDataSource))
     }
   }, [dispatch, instagramDataSource, isLoading])
-
-  useEffect(() => {
-    if (isShowingMore || !isLoading) {
-      VanillaTilt.init(document.querySelectorAll('.instagram-item-button'), {
-        glare: true,
-        max: 21,
-        perspective: 1500,
-        reverse: true,
-        speed: 300
-      })
-    }
-  }, [isLoading, isShowingMore])
 
   const openLightbox = useCallback(
     index => {
@@ -107,6 +97,7 @@ export default () => {
 
       <div className='gallery'>
         <Grid
+          className={classnames('media-item_grid', { 'media-item_grid--interacting': Boolean(focusedItem) })}
           sx={{
             gridGap: [3, 3, 3, 4],
             gridTemplateColumns: ['repeat(2, 1fr)', 'repeat(3, 1fr)', '', 'repeat(4, 1fr)']
@@ -132,7 +123,16 @@ export default () => {
               showLoadingAnimation
               type='rect'
             >
-              <WidgetItem handleClick={() => openLightbox(idx)} index={idx} post={post} />
+              <WidgetItem
+                isFocusedItem={focusedItem === post.id}
+                handleClick={() => openLightbox(idx)}
+                index={idx}
+                post={post}
+                onFocus={() => setFocusedItem(post.id)}
+                onBlur={() => setFocusedItem(null)}
+                onMouseEnter={() => setFocusedItem(post.id)}
+                onMouseLeave={() => setFocusedItem(null)}
+              />
             </ReactPlaceholder>
           ))}
         </Grid>

--- a/theme/src/components/widgets/instagram/instagram-widget.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.spec.js
@@ -6,7 +6,6 @@ import configureStore from 'redux-mock-store'
 import InstagramWidget from './instagram-widget'
 import { ThemeUIProvider } from 'theme-ui'
 import theme from '../../../gatsby-plugin-theme-ui'
-import VanillaTilt from 'vanilla-tilt'
 
 jest.mock('../../../hooks/use-site-metadata', () =>
   jest.fn(() => ({
@@ -27,7 +26,6 @@ jest.mock('lightgallery/plugins/zoom', () => jest.fn())
 jest.mock('lightgallery/plugins/video', () => jest.fn())
 jest.mock('lightgallery/plugins/autoplay', () => jest.fn())
 
-jest.mock('vanilla-tilt')
 jest.mock('../../../actions/fetchDataSource', () =>
   jest.fn(() => ({
     type: 'FETCH_DATASOURCE'
@@ -156,43 +154,6 @@ describe('InstagramWidget', () => {
     fireEvent.click(thumbnails[0])
 
     expect(mockLightGalleryInstance.openGallery).toHaveBeenCalledWith(0)
-  })
-
-  it('calls VanillaTilt.init when isShowingMore or !isLoading is true', () => {
-    render(
-      <ReduxProvider store={store}>
-        <ThemeUIProvider theme={theme}>
-          <InstagramWidget />
-        </ThemeUIProvider>
-      </ReduxProvider>
-    )
-
-    fireEvent.click(screen.getByText(/Show More/i))
-    expect(VanillaTilt.init).toHaveBeenCalled()
-
-    VanillaTilt.init.mockClear()
-
-    store = mockStore({
-      widgets: {
-        instagram: {
-          state: 'SUCCESS',
-          data: {
-            collections: { media: [] },
-            metrics: []
-          }
-        }
-      }
-    })
-
-    render(
-      <ReduxProvider store={store}>
-        <ThemeUIProvider theme={theme}>
-          <InstagramWidget />
-        </ThemeUIProvider>
-      </ReduxProvider>
-    )
-
-    expect(VanillaTilt.init).toHaveBeenCalled()
   })
 
   it('assigns lightGalleryRef correctly on initialization', () => {

--- a/theme/src/components/widgets/instagram/instagram-widget.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.spec.js
@@ -175,4 +175,34 @@ describe('InstagramWidget', () => {
 
     expect(mockInstance).toBeDefined()
   })
+
+  it('updates focusedItem state on focus, blur, mouse enter, and mouse leave', () => {
+    render(
+      <ReduxProvider store={store}>
+        <ThemeUIProvider theme={theme}>
+          <InstagramWidget />
+        </ThemeUIProvider>
+      </ReduxProvider>
+    )
+
+    // Locate the <button> wrapping the media item
+    const mediaItemButton = screen.getByRole('button', { name: /Instagram post thumbnail/i })
+    expect(mediaItemButton).toBeInTheDocument() // Ensure the button is rendered
+
+    // Focus event
+    fireEvent.focus(mediaItemButton)
+    expect(mediaItemButton.className).toContain('media-item--focused')
+
+    // Blur event
+    fireEvent.blur(mediaItemButton)
+    expect(mediaItemButton.className).not.toContain('media-item--focused')
+
+    // Mouse enter event
+    fireEvent.mouseEnter(mediaItemButton)
+    expect(mediaItemButton.className).toContain('media-item--focused')
+
+    // Mouse leave event
+    fireEvent.mouseLeave(mediaItemButton)
+    expect(mediaItemButton.className).not.toContain('media-item--focused')
+  })
 })

--- a/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
@@ -7,6 +7,8 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
   <a
     className="media-item_media css-1avyp1d"
     href="https://www.google.com/"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     title="Item #1"

--- a/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
@@ -1,212 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MediaItemGrid matches loading state snapshot 1`] = `
-<div
-  className="media-item_grid null css-4004kc"
->
-  <a
-    className="media-item_media css-1avyp1d"
-    href="https://www.google.com/"
-    onBlur={[Function]}
-    onFocus={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    title="Item #1"
+<DocumentFragment>
+  <div
+    class="media-item_grid null css-4004kc"
   >
-    <img
-      alt="cover artwork"
-      className="css-1yymcx5"
-      crossOrigin="anonymous"
-      loading="lazy"
-      src="http://placekitten.com/200/200"
-    />
-  </a>
-</div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+    <div
+      class="show-loading-animation"
+    >
+      <div
+        class="rect-shape css-l29vsk"
+        style="background-color: rgb(239, 239, 239); width: 100%; height: 100%; margin-right: 10px;"
+      />
+    </div>
+  </div>
+</DocumentFragment>
 `;
 
-exports[`MediaItemGrid matches the ready state snapshot state 1`] = `
-<div
-  className="media-item_grid null css-4004kc"
->
+exports[`MediaItemGrid matches the ready state snapshot 1`] = `
+<DocumentFragment>
   <div
-    className="show-loading-animation"
+    class="media-item_grid null css-4004kc"
   >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
+    <a
+      class="media-item_media css-1avyp1d"
+      href="https://www.google.com/"
+      title="Item #1"
+    >
+      <img
+        alt="cover artwork"
+        class="css-1yymcx5"
+        crossorigin="anonymous"
+        loading="lazy"
+        src="http://placekitten.com/200/200"
+      />
+    </a>
+    <a
+      class="media-item_media css-1avyp1d"
+      href="https://www.example.com/"
+      title="Item #2"
+    >
+      <img
+        alt="cover artwork"
+        class="css-1yymcx5"
+        crossorigin="anonymous"
+        loading="lazy"
+        src="http://placekitten.com/300/300"
+      />
+    </a>
   </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-  <div
-    className="show-loading-animation"
-  >
-    <div
-      className="rect-shape css-l29vsk"
-      style={
-        {
-          "backgroundColor": "#efefef",
-          "height": "100%",
-          "marginRight": 10,
-          "width": "100%",
-        }
-      }
-    />
-  </div>
-</div>
+</DocumentFragment>
 `;

--- a/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
@@ -24,6 +24,8 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
     <a
       className="media-item_media css-1avyp1d"
       href="http://spotify.com/track3"
+      onBlur={[Function]}
+      onFocus={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song Three – Artist Four"
@@ -292,6 +294,8 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
     <a
       className="media-item_media css-1avyp1d"
       href="http://spotify.com/track1"
+      onBlur={[Function]}
+      onFocus={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song One – Artist One, Artist Two"
@@ -307,6 +311,8 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
     <a
       className="media-item_media css-1avyp1d"
       href="http://spotify.com/track2"
+      onBlur={[Function]}
+      onFocus={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song Two – Artist Three"

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -42,8 +42,10 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
               className={`media-item_media${currentMediaId === id ? ' media-item--focused' : ''}`}
               href={spotifyURL}
               key={id}
+              onFocus={() => setCurrentMediaId(id)}
+              onBlur={() => setCurrentMediaId(null)}
               onMouseEnter={() => setCurrentMediaId(id)}
-              onMouseLeave={() => setCurrentMediaId(false)}
+              onMouseLeave={() => setCurrentMediaId(null)}
               title={details}
             >
               <Themed.img

--- a/theme/src/components/widgets/spotify/media-item-grid.spec.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.spec.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
 import MediaItemGrid from './media-item-grid'
 
 const mockItems = [
@@ -8,17 +9,53 @@ const mockItems = [
     details: 'Item #1',
     spotifyURL: 'https://www.google.com/',
     thumbnailURL: 'http://placekitten.com/200/200'
+  },
+  {
+    id: 'ITEM-2',
+    details: 'Item #2',
+    spotifyURL: 'https://www.example.com/',
+    thumbnailURL: 'http://placekitten.com/300/300'
   }
 ]
 
 describe('MediaItemGrid', () => {
   it('matches loading state snapshot', () => {
-    const tree = renderer.create(<MediaItemGrid isLoading={false} items={mockItems} />).toJSON()
-    expect(tree).toMatchSnapshot()
+    const { asFragment } = render(<MediaItemGrid isLoading={true} items={[]} />)
+    expect(asFragment()).toMatchSnapshot()
   })
 
-  it('matches the ready state snapshot state', () => {
-    const tree = renderer.create(<MediaItemGrid isLoading={true} items={[]} />).toJSON()
-    expect(tree).toMatchSnapshot()
+  it('matches the ready state snapshot', () => {
+    const { asFragment } = render(<MediaItemGrid isLoading={false} items={mockItems} />)
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  it('handles onFocus and onBlur correctly', () => {
+    render(<MediaItemGrid isLoading={false} items={mockItems} />)
+
+    const link = screen.getByTitle('Item #1')
+    expect(link).toBeInTheDocument()
+
+    // Trigger focus
+    fireEvent.focus(link)
+    expect(link).toHaveClass('media-item--focused')
+
+    // Trigger blur
+    fireEvent.blur(link)
+    expect(link).not.toHaveClass('media-item--focused')
+  })
+
+  it('handles onMouseEnter and onMouseLeave correctly', () => {
+    render(<MediaItemGrid isLoading={false} items={mockItems} />)
+
+    const link = screen.getByTitle('Item #1')
+    expect(link).toBeInTheDocument()
+
+    // Trigger mouse enter
+    fireEvent.mouseEnter(link)
+    expect(link).toHaveClass('media-item--focused')
+
+    // Trigger mouse leave
+    fireEvent.mouseLeave(link)
+    expect(link).not.toHaveClass('media-item--focused')
   })
 })

--- a/theme/src/styles/global.css
+++ b/theme/src/styles/global.css
@@ -49,6 +49,24 @@ article.c1v0-blog-post img.solid-background {
 
 .media-item_grid .media-item_media {
   transition: opacity 300ms ease;
+
+  &:focus {
+    outline: none;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.media-item--focused .media-item_icon {
+  opacity: 0; /* Initial state */
+  animation: fadeIn 0.25s ease-in-out forwards;
 }
 
 .media-item_grid--interacting .media-item_media:not(.media-item--focused) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15451,11 +15451,6 @@ value-or-promise@^1.0.12:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
   integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
-vanilla-tilt@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/vanilla-tilt/-/vanilla-tilt-1.8.1.tgz#09cb4dc89509a55a44bb221917bb8ecdc2e39113"
-  integrity sha512-hPB1XUsnh+SIeVSW2beb5RnuFxz4ZNgxjGD78o52F49gS4xaoLeEMh9qrQnJrnEn/vjjBI7IlxrrXmz4tGV0Kw==
-
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
This PR replaces the [**vanilla-tilt**](https://www.npmjs.com/package/vanilla-tilt) effect in my Instagram widget with the same effect I'm using in the other widgets.

### Before

https://github.com/user-attachments/assets/c700b213-413e-449d-be3b-1032b838fee2

### After

https://github.com/user-attachments/assets/9ea6030f-ce46-48c2-aa58-8c820d789db7
