### PR TITLE
feat: disable Vanilla Tilt glare and reset scale

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -65,11 +65,10 @@ export default () => {
   useEffect(() => {
     if (isShowingMore || !isLoading) {
       VanillaTilt.init(document.querySelectorAll('.instagram-item-button'), {
-        glare: true,
-        max: 21,
         perspective: 1500,
         reverse: true,
-        speed: 300
+        scale: 1.05,
+        speed: 200
       })
     }
   }, [isLoading, isShowingMore])


### PR DESCRIPTION
This PR disables the glare effect in the Instagram [**vanilla-tilt.js**](https://micku7zu.github.io/vanilla-tilt.js/) options and resets the custom `max` options, which controls the tilt amount, to the default setting.