### PR TITLE
fix: occasional, unhandled fatal errors in Playlists component

### DIFF
--- a/theme/src/components/widgets/spotify/playlist-error-boundary.spec.js
+++ b/theme/src/components/widgets/spotify/playlist-error-boundary.spec.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import PlaylistsErrorBoundary from './playlists-error-boundary'
+
+// A simple component that renders normally.
+const NormalChild = () => <div data-testid='normal-child'>I am fine</div>
+
+// A component that simulates a render error.
+const ErrorChild = () => {
+  throw new Error('Simulated error')
+}
+
+describe('PlaylistsErrorBoundary', () => {
+  // Suppress error logging for the test that intentionally causes an error.
+  const consoleError = console.error
+  beforeAll(() => {
+    console.error = () => {} // no-op
+  })
+
+  afterAll(() => {
+    console.error = consoleError
+  })
+
+  it('renders its children when no error is thrown', () => {
+    const { getByTestId } = render(
+      <PlaylistsErrorBoundary>
+        <NormalChild />
+      </PlaylistsErrorBoundary>
+    )
+    expect(getByTestId('normal-child')).toBeTruthy()
+  })
+
+  it('catches errors from children and renders null', () => {
+    const { container } = render(
+      <PlaylistsErrorBoundary>
+        <ErrorChild />
+      </PlaylistsErrorBoundary>
+    )
+    // When an error is caught, the boundary renders null,
+    // so container.firstChild should be null.
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/theme/src/components/widgets/spotify/playlists-error-boundary.js
+++ b/theme/src/components/widgets/spotify/playlists-error-boundary.js
@@ -1,0 +1,31 @@
+import { Component } from 'react'
+
+// This component is a temporary solution for an issue I've been observing the last month or two
+// where the Spotify Widget response data is missing images for the playlists. This causes a fatal
+// error in the component which takes down the entire Home page.
+class PlaylistsErrorBoundary extends Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error('Error in Playlists component:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // Don't render anything if there's an error. Most visitors, if not all, won't realize
+      // this is missing.
+      return null
+    }
+
+    return this.props.children
+  }
+}
+
+export default PlaylistsErrorBoundary

--- a/theme/src/components/widgets/spotify/spotify-widget.js
+++ b/theme/src/components/widgets/spotify/spotify-widget.js
@@ -6,6 +6,7 @@ import { faSpotify } from '@fortawesome/free-brands-svg-icons'
 
 import CallToAction from '../call-to-action'
 import Playlists from './playlists'
+import PlaylistsErrorBoundary from './playlists-error-boundary'
 import ProfileMetricsBadge from '../profile-metrics-badge'
 import TopTracks from './top-tracks'
 import Widget from '../widget'
@@ -62,7 +63,9 @@ const SpotifyWidget = () => {
       <ProfileMetricsBadge isLoading={isLoading} metrics={metrics} />
 
       <TopTracks isLoading={isLoading} tracks={topTracks} />
-      <Playlists isLoading={isLoading} playlists={playlists} />
+      <PlaylistsErrorBoundary>
+        <Playlists isLoading={isLoading} playlists={playlists} />
+      </PlaylistsErrorBoundary>
     </Widget>
   )
 }


### PR DESCRIPTION
Over the last month or two I have observed that occasionally the Metrics API will return `null` image data for the Spotify Playlists widget, which expects those to exist and then throws a fatal error that takes down the Home page. This PR guards against that until it's fixed by wrapping Playlists in [a React error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary).