### PR TITLE
feat: use Imgix params for Instagram images

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -12,7 +12,7 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
       crossorigin="anonymous"
       height="280"
       loading="lazy"
-      src="https://cdn.chrisvogt.me/images/fake-instagram-image.jpg?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format"
+      src="https://cdn.chrisvogt.me/images/fake-instagram-image.jpg?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format"
       width="280"
     />
   </button>

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -35,7 +35,7 @@ const InstagramWidgetItem = ({ handleClick, index, post: { caption, cdnMediaURL,
         crossOrigin='anonymous'
         className='instagram-item-image'
         loading='lazy'
-        src={`${cdnMediaURL}?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format`}
+        src={`${cdnMediaURL}?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format`}
         height='280'
         width='280'
         alt='Instagram post thumbnail'

--- a/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
@@ -34,7 +34,7 @@ describe('InstagramWidgetItem', () => {
     expect(img).toBeInTheDocument()
     expect(img).toHaveAttribute(
       'src',
-      `${defaultProps.post.cdnMediaURL}?h=280&w=280&fit=crop&crop=faces,focalpoint&auto=format`
+      `${defaultProps.post.cdnMediaURL}?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format`
     )
   })
 

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -155,7 +155,9 @@ export default () => {
           dynamicEl={media.map(post => ({
             thumb: post.cdnMediaURL,
             subHtml: post.caption || '',
-            ...(post.mediaType !== 'VIDEO' ? { src: post.cdnMediaURL } : {}),
+            ...(post.mediaType !== 'VIDEO'
+              ? { src: `${post.cdnMediaURL}?auto=compress&auto=enhance&auto=format` }
+              : {}),
             video:
               post.mediaType === 'VIDEO' && post.mediaURL
                 ? {


### PR DESCRIPTION
This PR applies the Imgix `auto` params described in https://docs.imgix.com/en-US/apis/rendering/automatic to the Instagram photos on my website. These will help reduce file size while also improving the quality of images.