### PR TITLE
feat: add missing icons and improve header sizes

### DIFF
--- a/theme/src/components/widgets/__snapshots__/widget-header.spec.js.snap
+++ b/theme/src/components/widgets/__snapshots__/widget-header.spec.js.snap
@@ -5,7 +5,7 @@ exports[`WidgetHeader matches the snapshot 1`] = `
   className="css-rcq65b"
 >
   <h2
-    className="css-zvxbld"
+    className="css-gifmxh"
   >
     Neat & Interesting Widget
   </h2>

--- a/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
@@ -9,20 +9,16 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
     className="css-gzw2dr"
   >
     <h2
-      className="css-1rxoh5f"
+      className="css-1s4ek1q"
     >
       <svg
         aria-hidden="true"
-        className="svg-inline--fa fa-github css-1ni16ne"
+        className="svg-inline--fa fa-github css-1vy0jp1"
         data-icon="github"
         data-prefix="fab"
         focusable="false"
         role="img"
-        style={
-          {
-            "height": "22px",
-          }
-        }
+        style={{}}
         viewBox="0 0 496 512"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
+++ b/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
@@ -9,20 +9,16 @@ exports[`Goodreads Widget matches the loading state snapshot 1`] = `
     className="css-gzw2dr"
   >
     <h2
-      className="css-1rxoh5f"
+      className="css-1s4ek1q"
     >
       <svg
         aria-hidden="true"
-        className="svg-inline--fa fa-goodreads css-1ni16ne"
+        className="svg-inline--fa fa-goodreads css-1vy0jp1"
         data-icon="goodreads"
         data-prefix="fab"
         focusable="false"
         role="img"
-        style={
-          {
-            "height": "22px",
-          }
-        }
+        style={{}}
         viewBox="0 0 448 512"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/theme/src/components/widgets/instagram/instagram-widget.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.js
@@ -30,6 +30,7 @@ import ProfileMetricsBadge from '../profile-metrics-badge'
 import Widget from '../widget'
 import WidgetHeader from '../widget-header'
 import WidgetItem from './instagram-widget-item'
+import { faInstagram } from '@fortawesome/free-brands-svg-icons'
 
 const MAX_IMAGES = {
   default: 8,
@@ -100,7 +101,9 @@ export default () => {
 
   return (
     <Widget id='instagram' hasFatalError={hasFatalError}>
-      <WidgetHeader aside={callToAction}>Instagram</WidgetHeader>
+      <WidgetHeader aside={callToAction} icon={faInstagram}>
+        Instagram
+      </WidgetHeader>
 
       <ProfileMetricsBadge metrics={metrics} isLoading={isLoading} />
 

--- a/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
@@ -9,20 +9,16 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
     className="css-gzw2dr"
   >
     <h2
-      className="css-1rxoh5f"
+      className="css-1s4ek1q"
     >
       <svg
         aria-hidden="true"
-        className="svg-inline--fa fa-spotify css-1ni16ne"
+        className="svg-inline--fa fa-spotify css-1vy0jp1"
         data-icon="spotify"
         data-prefix="fab"
         focusable="false"
         role="img"
-        style={
-          {
-            "height": "22px",
-          }
-        }
+        style={{}}
         viewBox="0 0 496 512"
         xmlns="http://www.w3.org/2000/svg"
       >

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -1,10 +1,11 @@
 /** @jsx jsx */
-import { Fragment, useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { get } from 'lodash'
 import { jsx } from 'theme-ui'
+import { faSteam } from '@fortawesome/free-brands-svg-icons'
+import { Fragment, useEffect } from 'react'
+import { get } from 'lodash'
 import { Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
+import { useDispatch, useSelector } from 'react-redux'
 import humanizeDuration from 'humanize-duration'
 
 import CallToAction from '../call-to-action'
@@ -59,7 +60,7 @@ const SteamWidget = () => {
 
   return (
     <Widget id='steam'>
-      <WidgetHeader aside={callToAction} isLoading={isLoading}>
+      <WidgetHeader aside={callToAction} icon={faSteam} isLoading={isLoading}>
         Steam
       </WidgetHeader>
 

--- a/theme/src/components/widgets/widget-header.js
+++ b/theme/src/components/widgets/widget-header.js
@@ -16,8 +16,8 @@ const asideStyles = {
 
 const WidgetHeader = ({ aside, children, icon }) => (
   <header sx={headerStyles}>
-    <Heading>
-      {icon && <FontAwesomeIcon icon={icon} style={{ height: '22px' }} sx={{ mr: 2 }} />}
+    <Heading sx={{ fontSize: 5, display: 'flex', alignItems: 'center' }}>
+      {icon && <FontAwesomeIcon icon={icon} sx={{ fontSize: 4, mr: 2 }} />}
       {children}
     </Heading>
     {aside && <div sx={asideStyles}>{aside}</div>}

--- a/theme/src/selectors/metadata.js
+++ b/theme/src/selectors/metadata.js
@@ -26,7 +26,7 @@ export const getLanguageCode = metadata => metadata?.languageCode
 
 export const getSpotifyWidgetDataSource = metadata => metadata?.widgets?.spotify?.widgetDataSource
 
-export const getSteamWidgetDataSource = metadata => metadata?.widgets?.steam?.widgetDataSource + '?cachebust=true'
+export const getSteamWidgetDataSource = metadata => metadata?.widgets?.steam?.widgetDataSource
 
 export const getSubhead = metadata => metadata?.subhead
 


### PR DESCRIPTION
This pull request introduces visual and functional updates to several widgets in the `theme/src/components/widgets` directory. Key changes include the addition of icons to widget headers, updates to snapshot tests, and minor code refactoring to improve readability and maintainability.

### Widget Header Enhancements:
* [`theme/src/components/widgets/widget-header.js`](diffhunk://#diff-448d7842b79ee93fde07d9b3e17c102a916b01031a8def612ce6dd1fca4ad538L19-R20): Updated the `WidgetHeader` component to support an `icon` prop, displaying icons alongside widget titles. Adjusted styles for better alignment and sizing.
* [`theme/src/components/widgets/instagram/instagram-widget.js`](diffhunk://#diff-5f966fd0babe67f97f24877f01338952dd1e11a26c97b18dcf211f2d5ab22382L103-R106): Added the Instagram icon (`faInstagram`) to the widget header using the new `icon` prop.
* [`theme/src/components/widgets/steam/steam-widget.js`](diffhunk://#diff-3d1e44016f066a4914eed1075686a89f04ab8f8bdfea0862aef56201d411d528L62-R63): Imported the Steam icon (`faSteam`) and updated the widget header to include it using the `icon` prop.

### Snapshot Test Updates:
* [`theme/src/components/widgets/__snapshots__/widget-header.spec.js.snap`](diffhunk://#diff-0c75045e0ee0ece1df0210229cf82432ea49a09ea363c53f62c87bc0797425fdL8-R8): Updated snapshot tests for `WidgetHeader` to reflect new CSS class changes.
* Snapshot tests for GitHub, Goodreads, Spotify, and other widgets updated to reflect new icon styles and CSS class changes. [[1]](diffhunk://#diff-b0d24bca983dcd613a645f6af651152e5d11d5addb42f0c4c684fdf8d3dccb4fL12-R21) [[2]](diffhunk://#diff-e99f8788e285734b5fe0a6cad368aa429915baad99f948edb18088828011310eL12-R21) [[3]](diffhunk://#diff-509062c42df304aef381f94efa4880e89ccf57847b9975b13da1a8e20af323aaL12-R21)

### Code Refactoring:
* [`theme/src/components/widgets/steam/steam-widget.js`](diffhunk://#diff-3d1e44016f066a4914eed1075686a89f04ab8f8bdfea0862aef56201d411d528R2-R8): Reorganized imports for better readability and added the `jsx` pragma explicitly.
* [`theme/src/selectors/metadata.js`](diffhunk://#diff-5e9e4220fda8abeba485dfa8608b07273e753a653f88d6dcf5fffe244c9160fdL29-R29): Removed unnecessary query parameter (`?cachebust=true`) from the Steam widget data source selector.