### PR TITLE
fix: resolve all warnings in unit tests

### DIFF
--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -25,6 +25,8 @@ export const TimeSpent = ({ timeInMs }) => (
   </Fragment>
 )
 
+const EMPTY_ARRAY = []
+
 const SteamWidget = () => {
   const dispatch = useDispatch()
   const metadata = useSiteMetadata()
@@ -34,22 +36,13 @@ const SteamWidget = () => {
     dispatch(fetchDataSource('steam', steamDataSource))
   }, [dispatch, steamDataSource])
 
-  const {
-    // hasFatalError,
-    isLoading,
-    metrics,
-    profileDisplayName,
-    profileURL,
-    recentlyPlayedGames
-  } = useSelector(state => ({
-    // hasFatalError: get(state, 'widgets.steam.state') === FAILURE,
-    isLoading: get(state, 'widgets.steam.state') !== SUCCESS,
-    metrics: get(state, 'widgets.steam.data.metrics', []),
-    profile: get(state, 'widgets.steam.data.profile'),
-    profileDisplayName: get(state, 'widgets.steam.data.profile.displayName'),
-    profileURL: get(state, 'widgets.steam.data.profile.profileURL'),
-    recentlyPlayedGames: get(state, 'widgets.steam.data.collections.recentlyPlayedGames', [])
-  }))
+  const isLoading = useSelector(state => get(state, 'widgets.steam.state') !== SUCCESS)
+  const metrics = useSelector(state => get(state, 'widgets.steam.data.metrics') ?? EMPTY_ARRAY)
+  const profileDisplayName = useSelector(state => get(state, 'widgets.steam.data.profile.displayName'))
+  const profileURL = useSelector(state => get(state, 'widgets.steam.data.profile.profileURL'))
+  const recentlyPlayedGames = useSelector(
+    state => get(state, 'widgets.steam.data.collections.recentlyPlayedGames') ?? EMPTY_ARRAY
+  )
 
   const callToAction = (
     <CallToAction title={`${profileDisplayName} on Steam`} url={profileURL} isLoading={isLoading}>

--- a/theme/src/pages/404.spec.js
+++ b/theme/src/pages/404.spec.js
@@ -32,7 +32,7 @@ const renderWithTheme = component => render(<ThemeUIProvider theme={mockTheme}>{
 
 describe('404 Page', () => {
   it('renders correctly', async () => {
-    renderWithTheme(<NotFoundPage />)
+    await waitFor(() => renderWithTheme(<NotFoundPage />))
 
     expect(screen.getByRole('heading', { name: '404' })).toBeInTheDocument()
     expect(screen.getByText(/Lost in space\?/i)).toBeInTheDocument()
@@ -41,19 +41,13 @@ describe('404 Page', () => {
 
   it('renders the Lottie animation after hydration', async () => {
     renderWithTheme(<NotFoundPage />)
-
-    // Wait for the loadable component to render
-    await waitFor(() => {
-      expect(screen.getByTestId('lottie-animation')).toBeInTheDocument()
-    })
+    expect(await screen.findByTestId('lottie-animation')).toBeInTheDocument()
   })
 
   it('renders the Layout component', async () => {
-    renderWithTheme(<NotFoundPage />)
+    await waitFor(() => renderWithTheme(<NotFoundPage />))
 
-    await waitFor(() => {
-      const layoutDiv = screen.getByText('Lottie Animation').closest('.layoutMock')
-      expect(layoutDiv).toBeInTheDocument()
-    })
+    const layoutDiv = screen.getByText('Lottie Animation').closest('.layoutMock')
+    expect(layoutDiv).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
This PR resolves all warnings rendered inside of the unit tests. After this change the unit tests run with no warnings ✅. Example of one of the warnings below.

<img width="1739" alt="Screenshot 2025-06-03 at 9 03 37 PM" src="https://github.com/user-attachments/assets/c4fd1cd6-71ee-4da5-81b0-ff2cb69ab143" />
