### PR TITLE
fix: headline positioning on small screens

### DIFF
--- a/theme/src/components/widgets/__snapshots__/widget-header.spec.js.snap
+++ b/theme/src/components/widgets/__snapshots__/widget-header.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`WidgetHeader matches the snapshot 1`] = `
 <header
-  className="css-rcq65b"
+  className="css-ef6z63"
 >
   <h2
     className="css-gifmxh"

--- a/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
@@ -6,7 +6,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
   id="github"
 >
   <header
-    className="css-gzw2dr"
+    className="css-x6ikgs"
   >
     <h2
       className="css-1s4ek1q"

--- a/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
+++ b/theme/src/components/widgets/goodreads/__snapshots__/goodreads-widget.spec.js.snap
@@ -6,7 +6,7 @@ exports[`Goodreads Widget matches the loading state snapshot 1`] = `
   id="goodreads"
 >
   <header
-    className="css-gzw2dr"
+    className="css-x6ikgs"
   >
     <h2
       className="css-1s4ek1q"

--- a/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/spotify-widget.spec.js.snap
@@ -6,7 +6,7 @@ exports[`Spotify Widget matches the loading state snapshot 1`] = `
   id="spotify"
 >
   <header
-    className="css-gzw2dr"
+    className="css-x6ikgs"
   >
     <h2
       className="css-1s4ek1q"

--- a/theme/src/components/widgets/widget-header.js
+++ b/theme/src/components/widgets/widget-header.js
@@ -7,7 +7,7 @@ const headerStyles = {
   textAlign: ['center', 'left'],
   display: 'flex',
   flexDirection: ['column', 'row'],
-  alignItems: ['', 'center']
+  alignItems: ['center', 'center']
 }
 
 const asideStyles = {


### PR DESCRIPTION
This pull request updates snapshot tests and refines the styling logic for widget headers in the `theme` package. The most important changes include modifications to snapshot files for various widgets and adjustments to the alignment logic in the `widget-header.js` file.

### Styling adjustments:

* [`theme/src/components/widgets/widget-header.js`](diffhunk://#diff-448d7842b79ee93fde07d9b3e17c102a916b01031a8def612ce6dd1fca4ad538L10-R10): Modified the `headerStyles` object to set `alignItems` to `['center', 'center']` instead of `['', 'center']`, ensuring consistent alignment across all screen sizes.

### Screenshots

Large screens still rendering left justified.

<img width="1597" alt="Screenshot 2025-06-03 at 9 32 00 PM" src="https://github.com/user-attachments/assets/dd0f8ce2-ef65-4ec8-b0b9-e25f6808a0d2" />

Headline text center aligned on a small screen.

<img width="612" alt="Screenshot 2025-06-03 at 9 31 53 PM" src="https://github.com/user-attachments/assets/1cbd1416-7251-4b4c-a4e8-c088deed154f" />

(Production) Headline text left aligned on a small screen. What I'm fixing.

<img width="612" alt="Screenshot 2025-06-03 at 9 31 46 PM" src="https://github.com/user-attachments/assets/ae5a102f-9189-4b65-9bc3-5f3c18d5f3e4" />

