### PR TITLE
feat: persists the audio player widget across pages

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,7 +46,8 @@ module.exports = [
       'jsx-a11y/no-noninteractive-element-interactions': 'warn',
       'react/prop-types': 'off',
       'react/jsx-uses-react': 'error',
-      'react/jsx-uses-vars': 'error'
+      'react/jsx-uses-vars': 'error',
+      'no-unused-vars': ['error', { varsIgnorePattern: '^React$' }]
     },
     settings: {
       react: {

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/__snapshots__/audio-player.spec.js.snap
+++ b/theme/src/components/__snapshots__/audio-player.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AudioPlayer matches snapshot when visible 1`] = `null`;

--- a/theme/src/components/__snapshots__/layout.spec.js.snap
+++ b/theme/src/components/__snapshots__/layout.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Layout matches the snapshot 1`] = `
 <div
-  className="css-9941j0"
+  className="css-ez1gh8"
 >
   <div
     style={

--- a/theme/src/components/__snapshots__/root-wrapper.spec.js.snap
+++ b/theme/src/components/__snapshots__/root-wrapper.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RootWrapper renders children and AudioPlayer 1`] = `
+[
+  <div>
+    Test Child
+  </div>,
+  <div>
+    MockAudioPlayer
+  </div>,
+]
+`;

--- a/theme/src/components/audio-player.js
+++ b/theme/src/components/audio-player.js
@@ -27,9 +27,9 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
     }
   }, [])
 
-  // Preserve widget instance
+  // Update widget when soundcloudId changes
   useEffect(() => {
-    if (soundcloudId && !widgetRef.current) {
+    if (soundcloudId) {
       widgetRef.current = soundcloudId
     }
   }, [soundcloudId])
@@ -113,7 +113,7 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
             }
           }}
         >
-          <SoundCloud soundcloudId={widgetRef.current || soundcloudId} />
+          <SoundCloud soundcloudId={soundcloudId} />
         </div>
       </div>
     </div>,

--- a/theme/src/components/audio-player.js
+++ b/theme/src/components/audio-player.js
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import { useState, useEffect } from 'react'
+import SoundCloud from '../shortcodes/soundcloud'
+
+const AudioPlayer = ({ soundcloudId, isVisible }) => {
+  if (!isVisible || !soundcloudId) return null
+
+  return (
+    <div
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        background: 'panel-background',
+        padding: 2,
+        boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
+        zIndex: 1000,
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center'
+      }}
+    >
+      <div sx={{ maxWidth: '800px', width: '100%' }}>
+        <SoundCloud soundcloudId={soundcloudId} />
+      </div>
+    </div>
+  )
+}
+
+export default AudioPlayer

--- a/theme/src/components/audio-player.js
+++ b/theme/src/components/audio-player.js
@@ -41,7 +41,11 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
         left: 0,
         right: 0,
         background: 'panel-background',
-        padding: 2,
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)', // for Safari
+        pt: 3,
+        pb: 2,
+        px: 3,
         boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
         zIndex: 1000,
         display: 'flex',
@@ -49,7 +53,22 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
         alignItems: 'center'
       }}
     >
-      <div sx={{ maxWidth: '800px', width: '100%' }}>
+      <div
+        sx={{
+          width: '100%',
+          maxWidth: [
+            '100%', // mobile: full width
+            '100%', // tablet: full width
+            '1200px', // desktop: max-width
+            '1400px' // large desktop: slightly wider
+          ],
+          '& iframe': {
+            width: '100% !important',
+            height: '100px !important', // fixed compact height
+            maxHeight: '100px !important'
+          }
+        }}
+      >
         <SoundCloud soundcloudId={widgetRef.current || soundcloudId} />
       </div>
     </div>,

--- a/theme/src/components/audio-player.js
+++ b/theme/src/components/audio-player.js
@@ -1,12 +1,39 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import { useState, useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import SoundCloud from '../shortcodes/soundcloud'
 
 const AudioPlayer = ({ soundcloudId, isVisible }) => {
-  if (!isVisible || !soundcloudId) return null
+  const containerRef = useRef(null)
+  const widgetRef = useRef(null)
 
-  return (
+  // Create portal container on mount
+  useEffect(() => {
+    if (!containerRef.current) {
+      containerRef.current = document.createElement('div')
+      containerRef.current.id = 'audio-player-portal'
+      document.body.appendChild(containerRef.current)
+    }
+
+    return () => {
+      if (containerRef.current) {
+        document.body.removeChild(containerRef.current)
+        containerRef.current = null
+      }
+    }
+  }, [])
+
+  // Preserve widget instance
+  useEffect(() => {
+    if (soundcloudId && !widgetRef.current) {
+      widgetRef.current = soundcloudId
+    }
+  }, [soundcloudId])
+
+  if (!isVisible || !soundcloudId || !containerRef.current) return null
+
+  return createPortal(
     <div
       sx={{
         position: 'fixed',
@@ -23,9 +50,10 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
       }}
     >
       <div sx={{ maxWidth: '800px', width: '100%' }}>
-        <SoundCloud soundcloudId={soundcloudId} />
+        <SoundCloud soundcloudId={widgetRef.current || soundcloudId} />
       </div>
-    </div>
+    </div>,
+    containerRef.current
   )
 }
 

--- a/theme/src/components/audio-player.js
+++ b/theme/src/components/audio-player.js
@@ -2,11 +2,14 @@
 import { jsx } from 'theme-ui'
 import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
+import { useDispatch } from 'react-redux'
+import { hidePlayer } from '../reducers/audioPlayer'
 import SoundCloud from '../shortcodes/soundcloud'
 
 const AudioPlayer = ({ soundcloudId, isVisible }) => {
   const containerRef = useRef(null)
   const widgetRef = useRef(null)
+  const dispatch = useDispatch()
 
   // Create portal container on mount
   useEffect(() => {
@@ -43,13 +46,13 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
         background: 'panel-background',
         backdropFilter: 'blur(8px)',
         WebkitBackdropFilter: 'blur(8px)', // for Safari
-        pt: 3,
-        pb: 2,
+        pt: 2,
+        pb: 3,
         px: 3,
         boxShadow: '0 -2px 10px rgba(0,0,0,0.1)',
         zIndex: 1000,
         display: 'flex',
-        justifyContent: 'center',
+        flexDirection: 'column',
         alignItems: 'center'
       }}
     >
@@ -62,14 +65,56 @@ const AudioPlayer = ({ soundcloudId, isVisible }) => {
             '1200px', // desktop: max-width
             '1400px' // large desktop: slightly wider
           ],
-          '& iframe': {
-            width: '100% !important',
-            height: '100px !important', // fixed compact height
-            maxHeight: '100px !important'
-          }
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-end'
         }}
       >
-        <SoundCloud soundcloudId={widgetRef.current || soundcloudId} />
+        <button
+          onClick={() => dispatch(hidePlayer())}
+          sx={{
+            background: 'none',
+            border: 'none',
+            color: 'text',
+            cursor: 'pointer',
+            p: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            borderRadius: '50%',
+            width: '32px',
+            height: '32px',
+            transition: 'all 0.2s ease',
+            mb: 1,
+            '&:hover': {
+              background: 'rgba(0,0,0,0.1)'
+            }
+          }}
+          aria-label='Close audio player'
+        >
+          <svg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'>
+            <path
+              d='M12 4L4 12M4 4L12 12'
+              stroke='currentColor'
+              strokeWidth='2'
+              strokeLinecap='round'
+              strokeLinejoin='round'
+            />
+          </svg>
+        </button>
+
+        <div
+          sx={{
+            width: '100%',
+            '& iframe': {
+              width: '100% !important',
+              height: '100px !important', // fixed compact height
+              maxHeight: '100px !important'
+            }
+          }}
+        >
+          <SoundCloud soundcloudId={widgetRef.current || soundcloudId} />
+        </div>
       </div>
     </div>,
     containerRef.current

--- a/theme/src/components/audio-player.spec.js
+++ b/theme/src/components/audio-player.spec.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import renderer, { act } from 'react-test-renderer'
+import configureStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+import AudioPlayer from '../components/audio-player'
+
+// Mock SoundCloud to avoid iframe logic
+jest.mock('../shortcodes/soundcloud', () => jest.fn(() => <div>MockSoundCloud</div>))
+
+const mockStore = configureStore([])
+
+describe('AudioPlayer', () => {
+  let store
+
+  beforeEach(() => {
+    store = mockStore({})
+    store.dispatch = jest.fn()
+    document.body.innerHTML = ''
+  })
+
+  it('renders and cleans up the portal container', async () => {
+    let component
+    await act(async () => {
+      component = renderer.create(
+        <Provider store={store}>
+          <AudioPlayer soundcloudId='abc' isVisible={true} />
+        </Provider>
+      )
+    })
+
+    expect(document.getElementById('audio-player-portal')).toBeTruthy()
+
+    await act(async () => {
+      component.unmount()
+    })
+
+    expect(document.getElementById('audio-player-portal')).toBeNull()
+  })
+
+  it('matches snapshot when visible', async () => {
+    // Only mock createPortal for this test
+    const createPortalMock = jest.spyOn(require('react-dom'), 'createPortal').mockImplementation(node => node)
+
+    let component
+    await act(async () => {
+      component = renderer.create(
+        <Provider store={store}>
+          <AudioPlayer soundcloudId='abc' isVisible={true} />
+        </Provider>
+      )
+    })
+
+    expect(component.toJSON()).toMatchSnapshot()
+
+    createPortalMock.mockRestore()
+  })
+})

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,5 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { useSelector } from 'react-redux'
 import React from 'react'
 
 import BackgroundPattern from './animated-background'
@@ -13,30 +14,37 @@ import TopNavigation from './top-navigation'
  * the default navigation, theme styles, and any important providers. Use shadowing
  * to extend this component and attach additional contexts and providers.
  */
-const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => (
-  <div
-    sx={{
-      backgroundColor: 'background',
-      position: 'relative', // stretch to full height
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-      color: theme => theme?.colors?.text
-    }}
-  >
-    <BackgroundPattern />
+const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => {
+  const { isVisible } = useSelector(state => state.audioPlayer)
 
-    {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
-    {!hideHeader && (
-      <header role='banner' sx={{ position: 'relative' }}>
-        <TopNavigation />
-      </header>
-    )}
+  return (
+    <div
+      sx={{
+        backgroundColor: 'background',
+        position: 'relative', // stretch to full height
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        color: theme => theme?.colors?.text,
+        // Add padding when audio player is visible
+        // 100px for player height + 24px (padding) + 16px (extra space)
+        pb: isVisible ? '140px' : 0
+      }}
+    >
+      <BackgroundPattern />
 
-    {disableMainWrapper ? children : <main role='main'>{children}</main>}
+      {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
+      {!hideHeader && (
+        <header role='banner' sx={{ position: 'relative' }}>
+          <TopNavigation />
+        </header>
+      )}
 
-    {!hideFooter && <Footer />}
-  </div>
-)
+      {disableMainWrapper ? children : <main role='main'>{children}</main>}
+
+      {!hideFooter && <Footer />}
+    </div>
+  )
+}
 
 export default Layout

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,6 +1,8 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
+import { useSelector } from 'react-redux'
 
+import AudioPlayer from './audio-player'
 import BackgroundPattern from './animated-background'
 import Footer from './footer'
 import TopNavigation from './top-navigation'
@@ -12,30 +14,36 @@ import TopNavigation from './top-navigation'
  * the default navigation, theme styles, and any important providers. Use shadowing
  * to extend this component and attach additional contexts and providers.
  */
-const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => (
-  <div
-    sx={{
-      backgroundColor: 'background',
-      position: 'relative', // stretch to full height
-      display: 'flex',
-      flexDirection: 'column',
-      flexGrow: 1,
-      color: theme => theme?.colors?.text
-    }}
-  >
-    <BackgroundPattern />
+const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => {
+  const { soundcloudId, isVisible } = useSelector(state => state.audioPlayer)
 
-    {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
-    {!hideHeader && (
-      <header role='banner' sx={{ position: 'relative' }}>
-        <TopNavigation />
-      </header>
-    )}
+  return (
+    <div
+      sx={{
+        backgroundColor: 'background',
+        position: 'relative', // stretch to full height
+        display: 'flex',
+        flexDirection: 'column',
+        flexGrow: 1,
+        color: theme => theme?.colors?.text
+      }}
+    >
+      <BackgroundPattern />
 
-    {disableMainWrapper ? children : <main role='main'>{children}</main>}
+      {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
+      {!hideHeader && (
+        <header role='banner' sx={{ position: 'relative' }}>
+          <TopNavigation />
+        </header>
+      )}
 
-    {!hideFooter && <Footer />}
-  </div>
-)
+      {disableMainWrapper ? children : <main role='main'>{children}</main>}
+
+      {!hideFooter && <Footer />}
+
+      <AudioPlayer soundcloudId={soundcloudId} isVisible={isVisible} />
+    </div>
+  )
+}
 
 export default Layout

--- a/theme/src/components/layout.js
+++ b/theme/src/components/layout.js
@@ -1,8 +1,7 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
-import { useSelector } from 'react-redux'
+import React from 'react'
 
-import AudioPlayer from './audio-player'
 import BackgroundPattern from './animated-background'
 import Footer from './footer'
 import TopNavigation from './top-navigation'
@@ -14,36 +13,30 @@ import TopNavigation from './top-navigation'
  * the default navigation, theme styles, and any important providers. Use shadowing
  * to extend this component and attach additional contexts and providers.
  */
-const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => {
-  const { soundcloudId, isVisible } = useSelector(state => state.audioPlayer)
+const Layout = ({ children, disableMainWrapper, hideHeader, hideFooter }) => (
+  <div
+    sx={{
+      backgroundColor: 'background',
+      position: 'relative', // stretch to full height
+      display: 'flex',
+      flexDirection: 'column',
+      flexGrow: 1,
+      color: theme => theme?.colors?.text
+    }}
+  >
+    <BackgroundPattern />
 
-  return (
-    <div
-      sx={{
-        backgroundColor: 'background',
-        position: 'relative', // stretch to full height
-        display: 'flex',
-        flexDirection: 'column',
-        flexGrow: 1,
-        color: theme => theme?.colors?.text
-      }}
-    >
-      <BackgroundPattern />
+    {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
+    {!hideHeader && (
+      <header role='banner' sx={{ position: 'relative' }}>
+        <TopNavigation />
+      </header>
+    )}
 
-      {/* NOTE(chrisvogt): hide the top navigation on the home and 404 pages */}
-      {!hideHeader && (
-        <header role='banner' sx={{ position: 'relative' }}>
-          <TopNavigation />
-        </header>
-      )}
+    {disableMainWrapper ? children : <main role='main'>{children}</main>}
 
-      {disableMainWrapper ? children : <main role='main'>{children}</main>}
-
-      {!hideFooter && <Footer />}
-
-      <AudioPlayer soundcloudId={soundcloudId} isVisible={isVisible} />
-    </div>
-  )
-}
+    {!hideFooter && <Footer />}
+  </div>
+)
 
 export default Layout

--- a/theme/src/components/layout.spec.js
+++ b/theme/src/components/layout.spec.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { ThemeUIProvider } from 'theme-ui'
+import { Provider } from 'react-redux'
+import configureStore from 'redux-mock-store'
 
 import Footer from './footer'
 import Layout from './layout'
@@ -28,17 +30,28 @@ describe('Layout', () => {
     }
   }
 
+  // Create mock store
+  const mockStore = configureStore([])
+  const store = mockStore({
+    audioPlayer: {
+      isVisible: false,
+      soundcloudId: null
+    }
+  })
+
   it('matches the snapshot', () => {
     const tree = renderer
       .create(
-        <ThemeUIProvider theme={mockTheme}>
-          <Layout>
-            <div className='fake-website'>
-              <h1>Fake Website</h1>
-              <p>Lorum ipsum dolor sit amet.</p>
-            </div>
-          </Layout>
-        </ThemeUIProvider>
+        <Provider store={store}>
+          <ThemeUIProvider theme={mockTheme}>
+            <Layout>
+              <div className='fake-website'>
+                <h1>Fake Website</h1>
+                <p>Lorum ipsum dolor sit amet.</p>
+              </div>
+            </Layout>
+          </ThemeUIProvider>
+        </Provider>
       )
       .toJSON()
 

--- a/theme/src/components/root-wrapper.js
+++ b/theme/src/components/root-wrapper.js
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import { useSelector } from 'react-redux'
+import React from 'react'
+
+import AudioPlayer from './audio-player'
+
+const RootWrapper = ({ children }) => {
+  const { soundcloudId, isVisible } = useSelector(state => state.audioPlayer)
+
+  return (
+    <>
+      {children}
+      <AudioPlayer soundcloudId={soundcloudId} isVisible={isVisible} />
+    </>
+  )
+}
+
+export default RootWrapper

--- a/theme/src/components/root-wrapper.spec.js
+++ b/theme/src/components/root-wrapper.spec.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import configureStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
+import RootWrapper from './root-wrapper'
+
+// Mock AudioPlayer component
+jest.mock('./audio-player', () => jest.fn(() => <div>MockAudioPlayer</div>))
+
+const mockStore = configureStore([])
+
+describe('RootWrapper', () => {
+  let store
+
+  beforeEach(() => {
+    store = mockStore({
+      audioPlayer: {
+        soundcloudId: '123',
+        isVisible: true
+      }
+    })
+    store.dispatch = jest.fn()
+  })
+
+  it('renders children and AudioPlayer', () => {
+    const component = renderer.create(
+      <Provider store={store}>
+        <RootWrapper>
+          <div>Test Child</div>
+        </RootWrapper>
+      </Provider>
+    )
+
+    expect(component.toJSON()).toMatchSnapshot()
+  })
+
+  it('passes correct props to AudioPlayer', () => {
+    const AudioPlayer = require('./audio-player')
+    renderer.create(
+      <Provider store={store}>
+        <RootWrapper>
+          <div>Test Child</div>
+        </RootWrapper>
+      </Provider>
+    )
+
+    expect(AudioPlayer).toHaveBeenCalledWith(
+      {
+        soundcloudId: '123',
+        isVisible: true
+      },
+      expect.anything()
+    )
+  })
+})

--- a/theme/src/reducers/audioPlayer.js
+++ b/theme/src/reducers/audioPlayer.js
@@ -1,0 +1,27 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+const initialState = {
+  soundcloudId: null,
+  isVisible: false
+}
+
+const audioPlayerSlice = createSlice({
+  name: 'audioPlayer',
+  initialState,
+  reducers: {
+    setSoundcloudTrack: (state, action) => {
+      state.soundcloudId = action.payload
+      state.isVisible = true
+    },
+    hidePlayer: state => {
+      state.isVisible = false
+    },
+    clearTrack: state => {
+      state.soundcloudId = null
+      state.isVisible = false
+    }
+  }
+})
+
+export const { setSoundcloudTrack, hidePlayer, clearTrack } = audioPlayerSlice.actions
+export default audioPlayerSlice.reducer

--- a/theme/src/reducers/audioPlayer.spec.js
+++ b/theme/src/reducers/audioPlayer.spec.js
@@ -1,0 +1,48 @@
+import reducer, { setSoundcloudTrack, hidePlayer, clearTrack } from '../reducers/audioPlayer'
+
+describe('audioPlayer reducer', () => {
+  const initialState = {
+    soundcloudId: null,
+    isVisible: false
+  }
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual(initialState)
+  })
+
+  it('should handle setSoundcloudTrack', () => {
+    const action = setSoundcloudTrack('abc123')
+    const result = reducer(initialState, action)
+
+    expect(result).toEqual({
+      soundcloudId: 'abc123',
+      isVisible: true
+    })
+  })
+
+  it('should handle hidePlayer', () => {
+    const prevState = {
+      soundcloudId: 'abc123',
+      isVisible: true
+    }
+    const result = reducer(prevState, hidePlayer())
+
+    expect(result).toEqual({
+      soundcloudId: 'abc123',
+      isVisible: false
+    })
+  })
+
+  it('should handle clearTrack', () => {
+    const prevState = {
+      soundcloudId: 'abc123',
+      isVisible: true
+    }
+    const result = reducer(prevState, clearTrack())
+
+    expect(result).toEqual({
+      soundcloudId: null,
+      isVisible: false
+    })
+  })
+})

--- a/theme/src/reducers/index.js
+++ b/theme/src/reducers/index.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux'
 
+import audioPlayerReducer from './audioPlayer'
 import widgetsReducer from './widgets'
 
 export default combineReducers({
+  audioPlayer: audioPlayerReducer,
   widgets: widgetsReducer
 })

--- a/theme/src/reducers/index.spec.js
+++ b/theme/src/reducers/index.spec.js
@@ -2,11 +2,13 @@ import rootReducer from './index'
 import widgetsReducer from './widgets'
 
 jest.mock('./widgets', () => jest.fn((state = { defaultKey: 'defaultValue' }) => state))
+jest.mock('./audioPlayer', () => jest.fn((state = { isVisible: false, soundcloudId: null }) => state))
 
 describe('rootReducer', () => {
   it('returns the initial state when no action is passed', () => {
     const initialState = rootReducer(undefined, {})
     expect(initialState).toEqual({
+      audioPlayer: { isVisible: false, soundcloudId: null },
       widgets: { defaultKey: 'defaultValue' }
     })
   })
@@ -25,7 +27,10 @@ describe('rootReducer', () => {
   })
 
   it('does not modify unrelated reducers', () => {
-    const initialState = { widgets: { exampleKey: 'exampleValue' } }
+    const initialState = {
+      audioPlayer: { isVisible: false, soundcloudId: null },
+      widgets: { exampleKey: 'exampleValue' }
+    }
     const action = { type: 'UNRELATED_ACTION' }
     const newState = rootReducer(initialState, action)
 

--- a/theme/src/templates/__snapshots__/media.spec.js.snap
+++ b/theme/src/templates/__snapshots__/media.spec.js.snap
@@ -5,19 +5,6 @@ exports[`Media Post renders correctly with a SoundCloud source 1`] = `
   className="layoutMock"
 >
   <div
-    className="css-rh73xg"
-  >
-    <div
-      className="css-io6end"
-    >
-      <div
-        className="soundcloudMock"
-      >
-        mockSoundCloudId
-      </div>
-    </div>
-  </div>
-  <div
     className="css-1v7u0sc"
   >
     <div

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -2,13 +2,15 @@
 import { Container, Flex, jsx } from 'theme-ui'
 import { Themed } from '@theme-ui/mdx'
 import { graphql } from 'gatsby'
+import React, { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
 
 import Category from '../components/category'
 import Layout from '../components/layout'
 import PageHeader from '../components/blog/page-header'
 import Seo from '../components/seo'
+import { setSoundcloudTrack } from '../reducers/audioPlayer'
 
-import SoundCloud from '../shortcodes/soundcloud'
 import YouTube from '../shortcodes/youtube'
 
 const getBanner = mdx => mdx.frontmatter.banner
@@ -16,15 +18,23 @@ const getDescription = mdx => mdx.frontmatter.description
 const getTitle = mdx => mdx.frontmatter.title
 
 const MediaTemplate = ({ data: { mdx }, children }) => {
+  const dispatch = useDispatch()
   const category = mdx.fields.category
   const date = mdx.frontmatter.date
   const soundcloudId = mdx.frontmatter.soundcloudId
   const title = getTitle(mdx)
   const youtubeSrc = mdx.frontmatter.youtubeSrc
 
+  // Set the SoundCloud track in Redux when this component mounts
+  useEffect(() => {
+    if (soundcloudId) {
+      dispatch(setSoundcloudTrack(soundcloudId))
+    }
+  }, [soundcloudId, dispatch])
+
   return (
     <Layout>
-      {(youtubeSrc || soundcloudId) && (
+      {youtubeSrc && (
         <Themed.div
           sx={{
             background: theme => theme.colors['panel-background'],
@@ -34,8 +44,7 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
           }}
         >
           <Container>
-            {youtubeSrc && <YouTube url={youtubeSrc} />}
-            {soundcloudId && <SoundCloud soundcloudId={soundcloudId} />}
+            <YouTube url={youtubeSrc} />
           </Container>
         </Themed.div>
       )}

--- a/theme/src/templates/media.spec.js
+++ b/theme/src/templates/media.spec.js
@@ -2,6 +2,8 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { ThemeUIProvider } from 'theme-ui'
 import { useStaticQuery } from 'gatsby'
+import { Provider } from 'react-redux'
+import configureStore from 'redux-mock-store'
 
 import Media, { Head } from './media'
 
@@ -28,6 +30,15 @@ const mockTheme = {
     'panel-background': '#f0f0f0'
   }
 }
+
+// Create mock store
+const mockStore = configureStore([])
+const store = mockStore({
+  audioPlayer: {
+    isVisible: false,
+    soundcloudId: null
+  }
+})
 
 jest.mock('gatsby')
 jest.mock('../components/layout', () => {
@@ -57,8 +68,13 @@ describe('Media Post', () => {
     jest.clearAllMocks()
   })
 
-  // Helper function to wrap components in the ThemeUIProvider
-  const renderWithTheme = component => renderer.create(<ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>)
+  // Helper function to wrap components in the ThemeUIProvider and Redux Provider
+  const renderWithTheme = component =>
+    renderer.create(
+      <Provider store={store}>
+        <ThemeUIProvider theme={mockTheme}>{component}</ThemeUIProvider>
+      </Provider>
+    )
 
   // Test with no media sources
   it('renders correctly with no media sources', () => {

--- a/theme/wrapRootElement.js
+++ b/theme/wrapRootElement.js
@@ -8,6 +8,7 @@ import { Themed } from '@theme-ui/mdx'
 import { ThemeUIProvider } from 'theme-ui'
 
 import Emoji from './src/shortcodes/emoji'
+import RootWrapper from './src/components/root-wrapper'
 import store from './src/store'
 import theme from './src/gatsby-plugin-theme-ui'
 import YouTube from './src/shortcodes/youtube'
@@ -28,7 +29,9 @@ const WrapRootElement = ({ element }) => (
     <ReduxProvider store={store}>
       <ThemeUIProvider theme={theme}>
         <Global styles={theme.global} />
-        <MDXProvider components={components}>{element}</MDXProvider>
+        <MDXProvider components={components}>
+          <RootWrapper>{element}</RootWrapper>
+        </MDXProvider>
       </ThemeUIProvider>
     </ReduxProvider>
   </CacheProvider>


### PR DESCRIPTION
This PR updates the SoundCloud blog posts so that they load a new audio player widget that lives outside of the blog post and inside of the page layout. That way visitors can navigate around the app and continue listening to the same song.

<img alt="An example showing a new audio player panel on the Home page" width="1633" alt="Screenshot 2025-06-08 at 2 01 51 AM" src="https://github.com/user-attachments/assets/3ee157b0-1085-4551-98b1-88a4c3ee2e3b" />
