### PR TITLE
fix(theme): sync color mode with system preference on first load

### DIFF
--- a/theme/gatsby-ssr.js
+++ b/theme/gatsby-ssr.js
@@ -1,3 +1,4 @@
+import React from 'react'
 export { default as wrapRootElement } from './wrapRootElement'
 
 export const onRenderBody = ({ setHtmlAttributes, setPreBodyComponents }) => {

--- a/theme/gatsby-ssr.js
+++ b/theme/gatsby-ssr.js
@@ -1,5 +1,20 @@
 export { default as wrapRootElement } from './wrapRootElement'
 
-export const onRenderBody = ({ setHtmlAttributes }) => {
+export const onRenderBody = ({ setHtmlAttributes, setPreBodyComponents }) => {
   setHtmlAttributes({ lang: 'en' })
+
+  const colorModeScript = `
+    (function() {
+      try {
+        var mode = localStorage.getItem('theme-ui-color-mode');
+        if (!mode) {
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          mode = prefersDark ? 'dark' : 'default';
+        }
+        document.documentElement.setAttribute('data-theme-ui-color-mode', mode);
+      } catch (e) {}
+    })();
+  `
+
+  setPreBodyComponents([<script key='theme-ui-no-flash' dangerouslySetInnerHTML={{ __html: colorModeScript }} />])
 }

--- a/theme/gatsby-ssr.spec.js
+++ b/theme/gatsby-ssr.spec.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import * as gatsbySSR from './gatsby-ssr'
+
+describe('gatsby-ssr', () => {
+  it('exports wrapRootElement', () => {
+    expect(gatsbySSR.wrapRootElement).toBeDefined()
+  })
+
+  it('sets html lang attribute and injects the color mode script', () => {
+    const setHtmlAttributes = jest.fn()
+    const setPreBodyComponents = jest.fn()
+
+    gatsbySSR.onRenderBody({ setHtmlAttributes, setPreBodyComponents })
+
+    // Assert the HTML lang attribute
+    expect(setHtmlAttributes).toHaveBeenCalledWith({ lang: 'en' })
+
+    // Extract the script element
+    expect(setPreBodyComponents).toHaveBeenCalledTimes(1)
+    const [scriptElement] = setPreBodyComponents.mock.calls[0][0]
+
+    // Render the script element using React Testing Library
+    const { container } = render(scriptElement)
+    const scriptTag = container.querySelector('script')
+
+    expect(scriptTag).toBeInTheDocument()
+    expect(scriptTag).toHaveTextContent(/localStorage\.getItem\(['"]theme-ui-color-mode['"]\)/)
+    expect(scriptTag).toHaveTextContent(/prefers-color-scheme/)
+    expect(scriptTag).toHaveTextContent(/data-theme-ui-color-mode/)
+  })
+})

--- a/theme/jest.config.js
+++ b/theme/jest.config.js
@@ -42,8 +42,13 @@ module.exports = {
     url: 'http://localhost'
   },
 
-  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],
+  // Transform modern JavaScript and JSX using Babel
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest'
+  },
+
+  // Allow specific ESM packages in node_modules to be transformed
+  transformIgnorePatterns: ['node_modules/(?!(gatsby|@mdx-js/react)/)'],
 
   // Indicates whether each individual test should be reported during the run
   verbose: false

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
+++ b/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
@@ -190,7 +190,8 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
     "textMuted": "#333",
   },
   "config": {
-    "useColorSchemeMediaQuery": "initial",
+    "initialColorModeName": "default",
+    "useColorSchemeMediaQuery": true,
     "useCustomProperties": true,
     "useLocalStorage": true,
   },

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -107,9 +107,10 @@ export const PostCard = {
 
 export default merge(tailwind, {
   config: {
-    useColorSchemeMediaQuery: 'initial', // Disable automatic detection of system preference
+    initialColorModeName: 'default', // or 'light', but default is fine
+    useColorSchemeMediaQuery: true, // enables respecting system preference
     useCustomProperties: true,
-    useLocalStorage: true // Persist user preferences
+    useLocalStorage: true
   },
 
   badges: {

--- a/theme/src/gatsby-plugin-theme-ui/theme.spec.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.spec.js
@@ -20,7 +20,7 @@ describe('Theme Configuration', () => {
     })
 
     it('defaults the color mode to dark', () => {
-      expect(theme.config.useColorSchemeMediaQuery).toBe('initial')
+      expect(theme.config.useColorSchemeMediaQuery).toBe(true)
       expect(theme.config.useCustomProperties).toBe(true)
       expect(theme.config.useLocalStorage).toBe(true)
     })


### PR DESCRIPTION
This PR attempts to fix a color mode hydration issue that I've noticed for some time. On Safari, when the page first renders, it doesn't always recognize the color mode toggle change until reloading the page.

### Screenshot

A demonstration of the page working via my local server and Safari.

https://github.com/user-attachments/assets/d73666d9-713d-4853-87b2-5e2b2b3bbf95

