### PR TITLE
fix: errors and alerts in WAVE about contrast and alt text

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.41.3",
+  "version": "0.41.4",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -7,7 +7,7 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
     rel="noopener noreferrer"
   >
     <img
-      alt="Instagram post thumbnail"
+      alt="Instagram post: This is a test caption"
       class="instagram-item-image css-16gz8ax"
       crossorigin="anonymous"
       height="280"

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -38,7 +38,7 @@ const InstagramWidgetItem = ({ handleClick, index, post: { caption, cdnMediaURL,
         src={`${cdnMediaURL}?h=234&w=234&fit=crop&crop=faces,focalpoint&auto=compress&auto=enhance&auto=format`}
         height='280'
         width='280'
-        alt='Instagram post thumbnail'
+        alt={caption ? `Instagram post: ${caption}` : 'Instagram post thumbnail'}
         sx={{
           width: '100%',
           height: '100%',

--- a/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.spec.js
@@ -30,7 +30,7 @@ describe('InstagramWidgetItem', () => {
   it('renders the image with correct alt text and source', () => {
     render(<InstagramWidgetItem {...defaultProps} />)
 
-    const img = screen.getByAltText('Instagram post thumbnail')
+    const img = screen.getByAltText(`Instagram post: ${defaultProps.post.caption}`)
     expect(img).toBeInTheDocument()
     expect(img).toHaveAttribute(
       'src',

--- a/theme/src/components/widgets/instagram/instagram-widget.spec.js
+++ b/theme/src/components/widgets/instagram/instagram-widget.spec.js
@@ -118,7 +118,7 @@ describe('InstagramWidget', () => {
       </ReduxProvider>
     )
 
-    const thumbnails = screen.getAllByAltText(/Instagram post thumbnail/i)
+    const thumbnails = screen.getAllByAltText(/Instagram post: Test Caption/i)
     expect(thumbnails).toHaveLength(1)
     expect(thumbnails[0]).toHaveAttribute(
       'src',
@@ -153,7 +153,7 @@ describe('InstagramWidget', () => {
       </ReduxProvider>
     )
 
-    const thumbnails = screen.getAllByAltText(/Instagram post thumbnail/i)
+    const thumbnails = screen.getAllByAltText(/Instagram post: Test Caption/i)
     fireEvent.click(thumbnails[0])
 
     expect(mockLightGalleryInstance.openGallery).toHaveBeenCalledWith(0)

--- a/theme/src/components/widgets/widget-header.js
+++ b/theme/src/components/widgets/widget-header.js
@@ -17,7 +17,7 @@ const asideStyles = {
 const WidgetHeader = ({ aside, children, icon }) => (
   <header sx={headerStyles}>
     <Heading sx={{ fontSize: 5, display: 'flex', alignItems: 'center' }}>
-      {icon && <FontAwesomeIcon icon={icon} sx={{ fontSize: 4, size: '24px', mr: 2 }} />}
+      {icon && <FontAwesomeIcon icon={icon} aria-hidden='true' sx={{ fontSize: 4, size: '24px', mr: 2 }} />}
       {children}
     </Heading>
     {aside && <div sx={asideStyles}>{aside}</div>}


### PR DESCRIPTION
This pull request includes updates to the `gatsby-theme-chrisvogt` package and improvements to accessibility and testing for Instagram widget components. Key changes include updating the package version, enhancing the alt text for Instagram images to include captions, and adding an `aria-hidden` attribute to icons for better accessibility.

<img width="1713" alt="A screenshot of the WAVE accessibility extension showing 7 contrast alerts and 5 nearby image alt text alerts" src="https://github.com/user-attachments/assets/42e77458-d664-4545-9594-437eb5620fce" />

### Package Update:
* [`theme/package.json`](diffhunk://#diff-864251b807b1925eadafb797a61b4fb855065215fc4e7129a00ec23a2dd4ed72L4-R4): Updated the package version from `0.41.3` to `0.41.4`.

### Accessibility Improvements:
* [`theme/src/components/widgets/instagram/instagram-widget-item.js`](diffhunk://#diff-2933ebab7842e24dca846ac4d05428d6c07932e608a968022dbe11bc2eb93fdaL41-R41): Enhanced the `alt` attribute for Instagram images to include the post's caption if available, improving accessibility and context for screen readers.
* [`theme/src/components/widgets/widget-header.js`](diffhunk://#diff-448d7842b79ee93fde07d9b3e17c102a916b01031a8def612ce6dd1fca4ad538L20-R20): Added the `aria-hidden="true"` attribute to icons in the widget header to ensure they are ignored by screen readers.

### Testing Updates:
* [`theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap`](diffhunk://#diff-82a4ac43a94914d4981c6ec18e4bad38fccaec1a4b0b389ff33bdeb5a0ef1686L10-R10): Updated the snapshot to reflect the new alt text format for Instagram images.
* [`theme/src/components/widgets/instagram/instagram-widget-item.spec.js`](diffhunk://#diff-39817bc407e0089971abe63c60bbe605eb260f0f9359551c5ff9723a25f45aeaL33-R33): Modified tests to validate the updated alt text for Instagram images.
* [`theme/src/components/widgets/instagram/instagram-widget.spec.js`](diffhunk://#diff-96694ddbd07224d4937815ee87771ce9b671e15a3fe548c74e15c504e1bfd05aL121-R121): Updated tests to match the new alt text format for Instagram thumbnails, ensuring consistency across the widget. [[1]](diffhunk://#diff-96694ddbd07224d4937815ee87771ce9b671e15a3fe548c74e15c504e1bfd05aL121-R121) [[2]](diffhunk://#diff-96694ddbd07224d4937815ee87771ce9b671e15a3fe548c74e15c504e1bfd05aL156-R156)