### PR TITLE
feat: apply common elevation styles to Spotify items

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
@@ -5,7 +5,7 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
   className="media-item_grid null css-4004kc"
 >
   <a
-    className="media-item_media css-a8fqp2"
+    className="media-item_media css-c3vfik"
     href="https://www.google.com/"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
@@ -13,7 +13,7 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
   >
     <img
       alt="cover artwork"
-      className="css-1g46s4f"
+      className="css-karewm"
       crossOrigin="anonymous"
       loading="lazy"
       src="http://placekitten.com/200/200"

--- a/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
@@ -22,14 +22,14 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
     className="media-item_grid null css-4004kc"
   >
     <a
-      className="media-item_media css-a8fqp2"
+      className="media-item_media css-c3vfik"
       href="http://spotify.com/track3"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song Three – Artist Four"
     >
       <div
-        className="media-item_caption css-18v1ukh"
+        className="media-item_caption css-764hy0"
       >
         <span>
           Song Three
@@ -37,7 +37,7 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
       </div>
       <img
         alt="cover artwork"
-        className="css-1g46s4f"
+        className="css-karewm"
         crossOrigin="anonymous"
         loading="lazy"
       />
@@ -297,14 +297,14 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
     className="media-item_grid null css-4004kc"
   >
     <a
-      className="media-item_media css-a8fqp2"
+      className="media-item_media css-c3vfik"
       href="http://spotify.com/track1"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song One – Artist One, Artist Two"
     >
       <div
-        className="media-item_caption css-18v1ukh"
+        className="media-item_caption css-764hy0"
       >
         <span>
           Song One
@@ -312,21 +312,21 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
       </div>
       <img
         alt="cover artwork"
-        className="css-1g46s4f"
+        className="css-karewm"
         crossOrigin="anonymous"
         loading="lazy"
         src="http://example.com/medium.jpg"
       />
     </a>
     <a
-      className="media-item_media css-a8fqp2"
+      className="media-item_media css-c3vfik"
       href="http://spotify.com/track2"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song Two – Artist Three"
     >
       <div
-        className="media-item_caption css-18v1ukh"
+        className="media-item_caption css-764hy0"
       >
         <span>
           Song Two
@@ -334,7 +334,7 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
       </div>
       <img
         alt="cover artwork"
-        className="css-1g46s4f"
+        className="css-karewm"
         crossOrigin="anonymous"
         loading="lazy"
         src="http://example.com/medium2.jpg"

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -5,7 +5,7 @@ import Placeholder from 'react-placeholder'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useState } from 'react'
 
-import { floatOnHover } from '../../../gatsby-plugin-theme-ui/theme'
+import { floatOnHover, glassmorhismPanel } from '../../../gatsby-plugin-theme-ui/theme'
 
 const placeholders = Array(12)
   .fill()
@@ -48,9 +48,12 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
               sx={{
                 display: 'flex',
                 position: 'relative',
-                borderRadius: '8px',
-                boxShadow: 'md',
-                overflow: 'hidden'
+                ...floatOnHover,
+                ...glassmorhismPanel,
+                overflow: 'hidden',
+                '&:hover .media-item_caption': {
+                  opacity: 1
+                }
               }}
             >
               {name && (
@@ -61,21 +64,20 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
                     fontSize: [1, 1, 1, 2],
                     fontWeight: 'bold',
                     opacity: 0,
-
+                    transition: 'opacity 0.2s ease-in-out',
                     alignItems: 'center',
                     display: 'flex',
                     justifyContent: 'center',
                     position: 'absolute',
                     textAlign: 'center',
-
                     padding: 2,
-
                     top: 0,
                     right: 0,
                     bottom: 0,
                     left: 0,
-
-                    background: 'rgba(0, 0, 0, 0.85)'
+                    background: 'rgba(0, 0, 0, 0.85)',
+                    backdropFilter: 'blur(2px)',
+                    WebkitBackdropFilter: 'blur(2px)'
                   }}
                 >
                   <span>{name}</span>
@@ -87,9 +89,10 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
                 loading='lazy'
                 src={thumbnailURL}
                 sx={{
-                  ...floatOnHover,
                   objectFit: 'cover',
-                  width: '100%'
+                  width: '100%',
+                  height: '100%',
+                  aspectRatio: '1/1'
                 }}
               />
             </Themed.a>


### PR DESCRIPTION
This PR applies common elevation, border and box shadow styles to the Spotify items, matching the Goodreads items.

### Screenshots

| Before | After |
|--------|-------|
|     <img width="1673" alt="light-before" src="https://github.com/user-attachments/assets/4a132591-38b0-44ec-8fd2-97bc57a309cd" />   |    <img width="1673" alt="light-after" src="https://github.com/user-attachments/assets/4523aad4-b8e3-4191-829a-b374a1e8e089" />   |
| <img width="1673" alt="dark-before" src="https://github.com/user-attachments/assets/9239af82-03d0-45a1-95b1-f128b4eef737" /> | <img width="1673" alt="dark-after" src="https://github.com/user-attachments/assets/3aa2abe1-5010-45c1-a20e-78efe7eeba73" /> |

This pull request includes updates to the `gatsby-theme-chrisvogt` package and enhancements to the `MediaItemGrid` component, improving its styling and functionality. It also updates snapshot tests to reflect these changes. Below are the most important changes:

### Package Updates:
* Updated the version of the `gatsby-theme-chrisvogt` package from `0.42.0` to `0.42.1` in `theme/package.json`.

### Component Styling Enhancements:
* Added `glassmorhismPanel` styling and hover effects to the `MediaItemGrid` component, improving its visual appearance. This includes a backdrop blur effect and smooth opacity transitions for captions. [[1]](diffhunk://#diff-478e54b1ab8b6f6ffcfa6e560036184b12e63ea981d9b97b57ee813caf53f84eL8-R8) [[2]](diffhunk://#diff-478e54b1ab8b6f6ffcfa6e560036184b12e63ea981d9b97b57ee813caf53f84eL51-R56) [[3]](diffhunk://#diff-478e54b1ab8b6f6ffcfa6e560036184b12e63ea981d9b97b57ee813caf53f84eL64-R80)
* Adjusted the image styling within `MediaItemGrid` to ensure consistent aspect ratio and better responsiveness.

### Snapshot Test Updates:
* Updated snapshot tests for `MediaItemGrid` and `TopTracks` components to reflect new class names and styling changes, ensuring test accuracy. [[1]](diffhunk://#diff-dec0e6acf00a5bb1e50e1d2df58f7a8879b51b1766a82090e54fd07315d3549aL8-R16) [[2]](diffhunk://#diff-bd07d9f9399407a0897a77e024ad9260d877d9e5f734f03a4d2610fa815f7e83L25-R40) [[3]](diffhunk://#diff-bd07d9f9399407a0897a77e024ad9260d877d9e5f734f03a4d2610fa815f7e83L300-R337)

