### PR TITLE
feat(design): standardize and reuse widget item hover styles

### DIFF
--- a/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap
@@ -184,7 +184,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
         className="css-nf0qmy"
       >
         <div
-          className="css-dqblq9"
+          className="css-1rkcmha"
         >
           <div
             className="show-loading-animation"
@@ -296,7 +296,7 @@ exports[`GitHub Widget matches the loading state snapshot 1`] = `
         className="css-nf0qmy"
       >
         <div
-          className="css-dqblq9"
+          className="css-1rkcmha"
         >
           <div
             className="show-loading-animation"

--- a/theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Widget/GitHub/PinnedItemCard snapshots matches the placeholder snapshot 1`] = `
 <div
-  className="css-1yz7e9k"
+  className="css-139dwiw"
 >
   <div
     className="show-loading-animation"
@@ -113,7 +113,7 @@ exports[`Widget/GitHub/PinnedItemCard snapshots matches the placeholder snapshot
 
 exports[`Widget/GitHub/PinnedItemCard snapshots matches the repository variant snapshot 1`] = `
 <div
-  className="css-1yz7e9k"
+  className="css-139dwiw"
 >
   <div
     className="css-1kbinjp"

--- a/theme/src/components/widgets/github/__snapshots__/pinned-items.spec.js.snap
+++ b/theme/src/components/widgets/github/__snapshots__/pinned-items.spec.js.snap
@@ -21,7 +21,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -133,7 +133,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -245,7 +245,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -357,7 +357,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the placeholder snapshot 1`
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -490,7 +490,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -602,7 +602,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -714,7 +714,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"
@@ -826,7 +826,7 @@ exports[`Widget/GitHub/PinnedItems snapshots matches the successful state 1`] = 
       className="css-1l9an2g"
     >
       <div
-        className="css-1yz7e9k"
+        className="css-139dwiw"
       >
         <div
           className="show-loading-animation"

--- a/theme/src/components/widgets/github/pinned-item-card.js
+++ b/theme/src/components/widgets/github/pinned-item-card.js
@@ -14,7 +14,20 @@ const rendererRegistry = {
 }
 
 const PinnedItemCard = ({ item, type = PLACEHOLDER }) => (
-  <Card variant='actionCard'>{rendererRegistry[type] && rendererRegistry[type](item)}</Card>
+  <Card
+    variant='actionCard'
+    sx={{
+      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      transition: 'transform 0.2s ease-in-out',
+      '&:hover': {
+        transform: 'translateY(-4px)'
+      }
+    }}
+  >
+    {rendererRegistry[type] && rendererRegistry[type](item)}
+  </Card>
 )
 
 export default PinnedItemCard

--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -8,7 +8,7 @@ exports[`PostCard matches the snapshot 1`] = `
   onMouseEnter={[Function]}
 >
   <div
-    className="css-1yz7e9k"
+    className="css-139dwiw"
   >
     <div
       className="card-content css-x4n4mc"

--- a/theme/src/components/widgets/recent-posts/post-card.js
+++ b/theme/src/components/widgets/recent-posts/post-card.js
@@ -14,7 +14,18 @@ export default ({ banner, category, date, excerpt, link, title }) => {
       }}
       to={link}
     >
-      <Card variant='PostCard'>
+      <Card
+        variant='PostCard'
+        sx={{
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          transition: 'transform 0.2s ease-in-out',
+          '&:hover': {
+            transform: 'translateY(-4px)'
+          }
+        }}
+      >
         <div
           className='card-content'
           sx={{

--- a/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap
@@ -5,19 +5,23 @@ exports[`MediaItemGrid matches loading state snapshot 1`] = `
   className="media-item_grid null css-4004kc"
 >
   <a
-    className="media-item_media css-c3vfik"
+    className="media-item_media css-1bdhn1b"
     href="https://www.google.com/"
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
     title="Item #1"
   >
-    <img
-      alt="cover artwork"
-      className="css-karewm"
-      crossOrigin="anonymous"
-      loading="lazy"
-      src="http://placekitten.com/200/200"
-    />
+    <div
+      className="css-x4b07x"
+    >
+      <img
+        alt="cover artwork"
+        className="css-karewm"
+        crossOrigin="anonymous"
+        loading="lazy"
+        src="http://placekitten.com/200/200"
+      />
+    </div>
   </a>
 </div>
 `;

--- a/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap
@@ -22,25 +22,29 @@ exports[`TopTracks Component handles tracks without a 300px image gracefully 1`]
     className="media-item_grid null css-4004kc"
   >
     <a
-      className="media-item_media css-c3vfik"
+      className="media-item_media css-1bdhn1b"
       href="http://spotify.com/track3"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song Three – Artist Four"
     >
       <div
-        className="media-item_caption css-764hy0"
+        className="css-x4b07x"
       >
-        <span>
-          Song Three
-        </span>
+        <div
+          className="media-item_caption css-764hy0"
+        >
+          <span>
+            Song Three
+          </span>
+        </div>
+        <img
+          alt="cover artwork"
+          className="css-karewm"
+          crossOrigin="anonymous"
+          loading="lazy"
+        />
       </div>
-      <img
-        alt="cover artwork"
-        className="css-karewm"
-        crossOrigin="anonymous"
-        loading="lazy"
-      />
     </a>
   </div>
 </div>
@@ -297,48 +301,56 @@ exports[`TopTracks Component renders correctly with tracks 1`] = `
     className="media-item_grid null css-4004kc"
   >
     <a
-      className="media-item_media css-c3vfik"
+      className="media-item_media css-1bdhn1b"
       href="http://spotify.com/track1"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song One – Artist One, Artist Two"
     >
       <div
-        className="media-item_caption css-764hy0"
+        className="css-x4b07x"
       >
-        <span>
-          Song One
-        </span>
+        <div
+          className="media-item_caption css-764hy0"
+        >
+          <span>
+            Song One
+          </span>
+        </div>
+        <img
+          alt="cover artwork"
+          className="css-karewm"
+          crossOrigin="anonymous"
+          loading="lazy"
+          src="http://example.com/medium.jpg"
+        />
       </div>
-      <img
-        alt="cover artwork"
-        className="css-karewm"
-        crossOrigin="anonymous"
-        loading="lazy"
-        src="http://example.com/medium.jpg"
-      />
     </a>
     <a
-      className="media-item_media css-c3vfik"
+      className="media-item_media css-1bdhn1b"
       href="http://spotify.com/track2"
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
       title="Song Two – Artist Three"
     >
       <div
-        className="media-item_caption css-764hy0"
+        className="css-x4b07x"
       >
-        <span>
-          Song Two
-        </span>
+        <div
+          className="media-item_caption css-764hy0"
+        >
+          <span>
+            Song Two
+          </span>
+        </div>
+        <img
+          alt="cover artwork"
+          className="css-karewm"
+          crossOrigin="anonymous"
+          loading="lazy"
+          src="http://example.com/medium2.jpg"
+        />
       </div>
-      <img
-        alt="cover artwork"
-        className="css-karewm"
-        crossOrigin="anonymous"
-        loading="lazy"
-        src="http://example.com/medium2.jpg"
-      />
     </a>
   </div>
 </div>

--- a/theme/src/components/widgets/spotify/media-item-grid.js
+++ b/theme/src/components/widgets/spotify/media-item-grid.js
@@ -5,7 +5,7 @@ import Placeholder from 'react-placeholder'
 import { RectShape } from 'react-placeholder/lib/placeholders'
 import { useState } from 'react'
 
-import { floatOnHover, glassmorhismPanel } from '../../../gatsby-plugin-theme-ui/theme'
+import { glassmorhismPanel } from '../../../gatsby-plugin-theme-ui/theme'
 
 const placeholders = Array(12)
   .fill()
@@ -46,9 +46,16 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
               onMouseLeave={() => setCurrentMediaId(false)}
               title={details}
               sx={{
-                display: 'flex',
+                display: 'block',
                 position: 'relative',
-                ...floatOnHover,
+                height: '100%',
+                width: '100%',
+                transition: 'all 200ms ease-in-out',
+                transform: 'translateY(0)',
+                '&:hover': {
+                  transform: 'translateY(-2px) scale(1.015)',
+                  boxShadow: 'lg'
+                },
                 ...glassmorhismPanel,
                 overflow: 'hidden',
                 '&:hover .media-item_caption': {
@@ -56,45 +63,54 @@ const MediaItemGrid = ({ isLoading, items = [] }) => {
                 }
               }}
             >
-              {name && (
-                <Themed.div
-                  className='media-item_caption'
-                  sx={{
-                    color: 'white',
-                    fontSize: [1, 1, 1, 2],
-                    fontWeight: 'bold',
-                    opacity: 0,
-                    transition: 'opacity 0.2s ease-in-out',
-                    alignItems: 'center',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    position: 'absolute',
-                    textAlign: 'center',
-                    padding: 2,
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                    left: 0,
-                    background: 'rgba(0, 0, 0, 0.85)',
-                    backdropFilter: 'blur(2px)',
-                    WebkitBackdropFilter: 'blur(2px)'
-                  }}
-                >
-                  <span>{name}</span>
-                </Themed.div>
-              )}
-              <Themed.img
-                alt='cover artwork'
-                crossOrigin='anonymous'
-                loading='lazy'
-                src={thumbnailURL}
+              <div
                 sx={{
-                  objectFit: 'cover',
-                  width: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
                   height: '100%',
-                  aspectRatio: '1/1'
+                  width: '100%'
                 }}
-              />
+              >
+                {name && (
+                  <Themed.div
+                    className='media-item_caption'
+                    sx={{
+                      color: 'white',
+                      fontSize: [1, 1, 1, 2],
+                      fontWeight: 'bold',
+                      opacity: 0,
+                      transition: 'opacity 0.2s ease-in-out',
+                      alignItems: 'center',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      position: 'absolute',
+                      textAlign: 'center',
+                      padding: 2,
+                      top: 0,
+                      right: 0,
+                      bottom: 0,
+                      left: 0,
+                      background: 'rgba(0, 0, 0, 0.85)',
+                      backdropFilter: 'blur(2px)',
+                      WebkitBackdropFilter: 'blur(2px)'
+                    }}
+                  >
+                    <span>{name}</span>
+                  </Themed.div>
+                )}
+                <Themed.img
+                  alt='cover artwork'
+                  crossOrigin='anonymous'
+                  loading='lazy'
+                  src={thumbnailURL}
+                  sx={{
+                    objectFit: 'cover',
+                    width: '100%',
+                    height: '100%',
+                    aspectRatio: '1/1'
+                  }}
+                />
+              </div>
             </Themed.a>
           )
         })}


### PR DESCRIPTION
This pull request introduces updates to the styling and behavior of several UI components across the GitHub, Recent Posts, and Spotify widgets, focusing on hover effects, layout improvements, and snapshot updates. The changes enhance the user experience by adding hover animations and improving layout consistency. Below are the most important changes grouped by theme:

### Styling and Hover Effects:

* **GitHub Pinned Item Card**: Added hover effects to the `PinnedItemCard` component, including a slight upward translation and scaling effect on hover, along with a smooth transition (`theme/src/components/widgets/github/pinned-item-card.js`).
* **Recent Posts Post Card**: Updated the `PostCard` component to include hover animations with a similar upward translation and scaling effect (`theme/src/components/widgets/recent-posts/post-card.js`).
* **Spotify Media Item Grid**: Enhanced the hover behavior of media items in the `MediaItemGrid` component by introducing scaling, translation, and shadow effects. Adjusted the layout to use `block` display and added a flex container for consistent alignment (`theme/src/components/widgets/spotify/media-item-grid.js`). [[1]](diffhunk://#diff-478e54b1ab8b6f6ffcfa6e560036184b12e63ea981d9b97b57ee813caf53f84eL49-R72) [[2]](diffhunk://#diff-478e54b1ab8b6f6ffcfa6e560036184b12e63ea981d9b97b57ee813caf53f84eR113)

### Snapshot Updates:

* **GitHub Widgets**: Updated snapshot tests for the `GitHub Widget` and `PinnedItemCard` components to reflect changes in class names and layout (`theme/src/components/widgets/github/__snapshots__/github-widget.spec.js.snap`, `theme/src/components/widgets/github/__snapshots__/pinned-item-card.spec.js.snap`). [[1]](diffhunk://#diff-b0d24bca983dcd613a645f6af651152e5d11d5addb42f0c4c684fdf8d3dccb4fL187-R187) [[2]](diffhunk://#diff-ba6da1601b596b9137f5d029303a44544fdd7126450d050261ef955b8608a18dL5-R5)
* **Spotify Widgets**: Updated snapshots for `MediaItemGrid` and `TopTracks` components to account for new class names and structural changes (`theme/src/components/widgets/spotify/__snapshots__/media-item-grid.spec.js.snap`, `theme/src/components/widgets/spotify/__snapshots__/top-tracks.spec.js.snap`). [[1]](diffhunk://#diff-dec0e6acf00a5bb1e50e1d2df58f7a8879b51b1766a82090e54fd07315d3549aL8-R15) [[2]](diffhunk://#diff-bd07d9f9399407a0897a77e024ad9260d877d9e5f734f03a4d2610fa815f7e83L25-R32)

### Code Cleanup:

* **Removed Unused Imports**: Eliminated the unused `floatOnHover` import from the `MediaItemGrid` component to clean up the codebase (`theme/src/components/widgets/spotify/media-item-grid.js`).