### PR TITLE
fix: recently read book scrolling in Safari

### DIFF
--- a/theme/src/components/widgets/goodreads/book-link.js
+++ b/theme/src/components/widgets/goodreads/book-link.js
@@ -17,21 +17,27 @@ const BookLink = ({ id, thumbnailURL, title }) => {
 
   const handleClick = e => {
     e.preventDefault()
-    console.log('BookLink click:', {
-      id,
-      title,
-      scrollY: window.scrollY,
-      pathname: window.location.pathname,
-      search: window.location.search
-    })
-    // Use Gatsby's navigate for the initial click
-    gatsbyNavigate(`?bookId=${id}`, {
-      replace: true,
-      state: {
-        noScroll: true,
-        scrollPosition: window.scrollY
-      }
-    })
+    e.stopPropagation() // Prevent event bubbling
+    // Store current scroll position
+    const currentScroll = window.scrollY
+    // Use a small timeout to ensure the scroll position is preserved
+    setTimeout(() => {
+      console.log('BookLink click:', {
+        id,
+        title,
+        scrollY: currentScroll,
+        pathname: window.location.pathname,
+        search: window.location.search
+      })
+      // Use Gatsby's navigate for the initial click
+      gatsbyNavigate(`?bookId=${id}`, {
+        replace: true,
+        state: {
+          noScroll: true,
+          scrollPosition: currentScroll
+        }
+      })
+    }, 0)
   }
 
   return (

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -46,12 +46,14 @@ describe('Widget/Goodreads/BookLink', () => {
     expect(image).toHaveAttribute('xlink:href', 'https://example.com/book.jpg')
   })
 
-  it('handles click events with scroll position preservation', () => {
+  it('handles click events with scroll position preservation', async () => {
     // Mock window.scrollY
     Object.defineProperty(window, 'scrollY', { value: 200 })
     render(<BookLink {...mockProps} />)
     const link = screen.getByTestId('book-link')
     fireEvent.click(link)
+    // Wait for the setTimeout to complete
+    await new Promise(resolve => setTimeout(resolve, 0))
     expect(gatsbyNavigate).toHaveBeenCalledWith('?bookId=123', {
       replace: true,
       state: {
@@ -61,10 +63,18 @@ describe('Widget/Goodreads/BookLink', () => {
     })
   })
 
-  it('logs click event details for debugging', () => {
+  it('logs click event details for debugging', async () => {
+    // Mock window.scrollY and location
+    Object.defineProperty(window, 'scrollY', { value: 200 })
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/', search: '' },
+      writable: true
+    })
     render(<BookLink {...mockProps} />)
     const link = screen.getByTestId('book-link')
     fireEvent.click(link)
+    // Wait for the setTimeout to complete
+    await new Promise(resolve => setTimeout(resolve, 0))
     expect(console.log).toHaveBeenCalledWith('BookLink click:', {
       id: '123',
       title: 'Test Book',

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -18,23 +18,54 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
   const bookId = params.get('bookId')
   const selectedBook = bookId ? books.find(book => book.id === bookId) : null
 
-  // Handle scroll position restoration
+  // Handle scroll position restoration and prevention
   useEffect(() => {
+    // Store the current scroll position when the component mounts
+    const scrollPosition = window.scrollY
+
+    // If we have a scroll position in state, restore it
     if (location.state?.scrollPosition) {
       console.log('Restoring scroll position:', location.state.scrollPosition)
-      window.scrollTo(0, location.state.scrollPosition)
+      // Use requestAnimationFrame to ensure smooth restoration
+      requestAnimationFrame(() => {
+        window.scrollTo({
+          top: location.state.scrollPosition,
+          behavior: 'instant' // Use instant to prevent animation
+        })
+      })
+    } else if (location.state?.noScroll) {
+      // If noScroll is true, maintain the current position
+      requestAnimationFrame(() => {
+        window.scrollTo({
+          top: scrollPosition,
+          behavior: 'instant'
+        })
+      })
     }
-  }, [location.state])
+
+    // Cleanup function to handle component unmount
+    return () => {
+      // Store the current scroll position when unmounting
+      if (window.scrollY !== scrollPosition) {
+        window.scrollTo({
+          top: scrollPosition,
+          behavior: 'instant'
+        })
+      }
+    }
+  }, [location.state, location.search]) // Add location.search to dependencies
 
   const handleClose = e => {
     if (e) {
       e.preventDefault()
     }
+    const currentScroll = window.scrollY
     // Use replace to avoid adding to history stack
     navigate(location.pathname, {
       replace: true,
       state: {
-        scrollPosition: window.scrollY
+        scrollPosition: currentScroll,
+        noScroll: true
       }
     })
   }

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -23,8 +23,21 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
     // Store the current scroll position when the component mounts
     const scrollPosition = window.scrollY
 
+    // If we have a bookId in the URL on initial render, scroll to the goodreads element
+    if (bookId && !location.state?.scrollPosition && !location.state?.noScroll) {
+      // Use a small delay to ensure the element is ready, especially in Chrome
+      setTimeout(() => {
+        const goodreadsElement = document.getElementById('goodreads')
+        if (goodreadsElement) {
+          // Force a reflow to ensure the element is properly positioned
+          goodreadsElement.offsetHeight
+          // Use the browser's native hash navigation
+          window.location.hash = 'goodreads'
+        }
+      }, 100)
+    }
     // If we have a scroll position in state, restore it
-    if (location.state?.scrollPosition) {
+    else if (location.state?.scrollPosition) {
       console.log('Restoring scroll position:', location.state.scrollPosition)
       // Use requestAnimationFrame to ensure smooth restoration
       requestAnimationFrame(() => {
@@ -53,7 +66,7 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
         })
       }
     }
-  }, [location.state, location.search]) // Add location.search to dependencies
+  }, [location.state, location.search, bookId]) // Add bookId to dependencies
 
   const handleClose = e => {
     if (e) {

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -54,13 +54,21 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
   describe('navigation and scroll behavior', () => {
     const mockNavigate = jest.fn()
     const mockScrollTo = jest.fn()
+    const mockGetElementById = jest.fn()
 
     beforeEach(() => {
       window.scrollTo = mockScrollTo
+      window.document.getElementById = mockGetElementById
       mockNavigate.mockClear()
       mockScrollTo.mockClear()
+      mockGetElementById.mockClear()
       // Mock navigate function
       jest.spyOn(require('@gatsbyjs/reach-router'), 'navigate').mockImplementation(mockNavigate)
+      // Mock window.location.hash
+      Object.defineProperty(window, 'location', {
+        value: { hash: '' },
+        writable: true
+      })
     })
 
     it('restores scroll position when location state contains scrollPosition', async () => {
@@ -129,6 +137,89 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
           noScroll: true // Add the noScroll property to match component behavior
         }
       })
+    })
+
+    it('scrolls to goodreads element when bookId is present and no scroll state', async () => {
+      const mockElement = { offsetHeight: 100 }
+      mockGetElementById.mockReturnValue(mockElement)
+      render(
+        <LocationProvider
+          history={{
+            location: { pathname: '/', search: '?bookId=123' },
+            listen: () => () => {},
+            navigate: () => {},
+            _onTransitionComplete: () => {}
+          }}
+        >
+          <Router>
+            <div id='goodreads' default />
+            <RecentlyReadBooks books={mockBooks} isLoading={false} default />
+          </Router>
+        </LocationProvider>
+      )
+
+      // Wait for setTimeout
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect(mockGetElementById).toHaveBeenCalledWith('goodreads')
+      expect(window.location.hash).toBe('goodreads')
+    })
+
+    it('handles cleanup on unmount with different scroll position', () => {
+      const initialScroll = 100
+      const newScroll = 500
+      Object.defineProperty(window, 'scrollY', { value: initialScroll })
+      const { unmount } = render(
+        <LocationProvider
+          history={{
+            location: { pathname: '/' },
+            listen: () => () => {},
+            navigate: () => {},
+            _onTransitionComplete: () => {}
+          }}
+        >
+          <Router>
+            <div default>
+              <RecentlyReadBooks books={mockBooks} isLoading={false} default />
+            </div>
+          </Router>
+        </LocationProvider>
+      )
+
+      // Change scroll position
+      Object.defineProperty(window, 'scrollY', { value: newScroll })
+      // Unmount component
+      unmount()
+      // Should restore initial scroll position
+      expect(mockScrollTo).toHaveBeenCalledWith({
+        top: initialScroll,
+        behavior: 'instant'
+      })
+    })
+
+    it('does not restore scroll position on unmount if unchanged', () => {
+      const scrollPosition = 100
+      Object.defineProperty(window, 'scrollY', { value: scrollPosition })
+      const { unmount } = render(
+        <LocationProvider
+          history={{
+            location: { pathname: '/' },
+            listen: () => () => {},
+            navigate: () => {},
+            _onTransitionComplete: () => {}
+          }}
+        >
+          <Router>
+            <div default>
+              <RecentlyReadBooks books={mockBooks} isLoading={false} default />
+            </div>
+          </Router>
+        </LocationProvider>
+      )
+
+      // Unmount component without changing scroll position
+      unmount()
+      // Should not call scrollTo since position hasn't changed
+      expect(mockScrollTo).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
This PR fixes 1) fixes a bug in Safari where clicking a book in the book explorer would scroll to the top of the page. It also 2) adds a new behavior to scroll to the book explorer when opened with a **bookId** query param.

### Screenshot

A demonstration of the bug(s) in Safari.

https://github.com/user-attachments/assets/c08e1786-a85f-4e60-af05-e70dce12b173

A demonstration of the issue fixed via the deploy preview link.

https://github.com/user-attachments/assets/ae4d888b-ada7-497f-911f-e67b7968f713
