### PR TITLE
chore: organize postinstall script and convert it to CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "develop": "yarn workspace www.chrisvogt.me develop:https",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css,md,mdx}\"",
     "lint": "eslint",
-    "postinstall": "node index.js",
+    "postinstall": "node ./scripts/postinstall-banner.js",
     "prepare": "husky",
     "prettier": "prettier",
     "test:coverage": "yarn workspace gatsby-theme-chrisvogt test --coverage",

--- a/scripts/postinstall-banner.js
+++ b/scripts/postinstall-banner.js
@@ -1,0 +1,21 @@
+const boxen = require('boxen').default
+const chalk = require('chalk')
+const packageData = require('../theme/package.json')
+
+const banner = boxen(`${chalk.bold('www.chrisvogt.me')}\nMy Personal Website\nv${packageData.version}`, {
+  align: 'center',
+  backgroundColor: '#9b20dc',
+  borderStyle: 'round',
+  borderColor: '#7319a6',
+  color: 'white',
+  padding: {
+    top: 1,
+    right: 8,
+    bottom: 1,
+    left: 8
+  }
+})
+
+console.log(banner)
+
+console.log(`✅  Installation succeeded: ${chalk.bold('gatsby-theme-chrisvogt')}`)


### PR DESCRIPTION
This small PR converts the postinstall script into CommonJS to stop a warning I'm seeing about re-parsing it as a different format. It also moves it to a new directory for better organization.

This pull request updates the post-installation process for the project by replacing the previous script with a more user-friendly banner display. It introduces a new script that uses `boxen` and `chalk` to display a styled banner with project information after installation.

**Post-installation process updates:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11-R11): Updated the `postinstall` script to use `./scripts/postinstall-banner.js` instead of `index.js`.
* [`scripts/postinstall-banner.js`](diffhunk://#diff-f75b1506109c7150daf3ec89fb38c85728def6c5fb05447b828d65d34e98f622R1-R21): Added a new script that displays a styled banner with project information (e.g., name, description, version) using `boxen` and `chalk`. It also logs a success message for the installation of the `gatsby-theme-chrisvogt` package.