### PR TITLE
feat: add View Source to footer and remove rel='' attributes

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/footer/footer.js
+++ b/theme/src/components/footer/footer.js
@@ -29,6 +29,10 @@ export default () => {
             <span>
               <Link to='/privacy'>Privacy Policy</Link>
             </span>
+            {' | '}
+            <span>
+              <Link to='https://github.com/chrisvogt/gatsby-theme-chrisvogt'>View Source</Link>
+            </span>
           </div>
         </div>
       </Container>

--- a/theme/src/components/widgets/goodreads/book-explorer.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.js
@@ -120,7 +120,6 @@ const BookExplorer = ({ book, onClose }) => {
 
             <Themed.a
               href={infoLink}
-              rel='noopener noreferrer'
               sx={{
                 display: 'inline-flex',
                 alignItems: 'center',

--- a/theme/src/components/widgets/goodreads/book-explorer.spec.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.spec.js
@@ -96,7 +96,6 @@ describe('Widget/Goodreads/BookExplorer', () => {
   it('renders external link without target="_blank"', () => {
     renderWithRouter(<BookExplorer book={mockBook} onClose={() => {}} default />)
     const link = screen.getByText('Learn more on Google Books')
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     expect(link).not.toHaveAttribute('target')
   })
 })

--- a/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
+++ b/theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap
@@ -4,7 +4,6 @@ exports[`InstagramWidgetItem matches the snapshot 1`] = `
 <DocumentFragment>
   <button
     class="instagram-item-button css-1u8qly9"
-    rel="noopener noreferrer"
   >
     <img
       alt="Instagram post: This is a test caption"

--- a/theme/src/components/widgets/instagram/instagram-widget-item.js
+++ b/theme/src/components/widgets/instagram/instagram-widget-item.js
@@ -11,7 +11,6 @@ const InstagramWidgetItem = ({ handleClick, index, post: { caption, cdnMediaURL,
     <button
       key={id}
       onClick={event => handleClick(event, { index, photo: { caption, id, src: cdnMediaURL } })}
-      rel='noopener noreferrer'
       className='instagram-item-button'
       sx={{
         variant: 'styles.InstagramItem'


### PR DESCRIPTION
This PR adds a new View Source link to the footer, which links to this repository. It also removes unnecessary rel='' attributes on links that open in the tab and are to destinations I trust (GitHub, Goodreads, Instagram, etc).

### Screenshot

<img width="787" alt="Screenshot 2025-06-12 at 11 33 27 PM" src="https://github.com/user-attachments/assets/8af506c7-27fd-4e14-852c-10f66d5b40d0" />

This pull request includes several updates to the `gatsby-theme-chrisvogt` project, focusing on versioning, UI enhancements, and code cleanup. The most notable changes involve adding a "View Source" link to the footer, removing unnecessary `rel='noopener noreferrer'` attributes, and updating the theme version.

### Versioning:
* [`theme/package.json`](diffhunk://#diff-864251b807b1925eadafb797a61b4fb855065215fc4e7129a00ec23a2dd4ed72L4-R4): Updated the theme version from `0.42.1` to `0.42.2`.

### UI Enhancements:
* [`theme/src/components/footer/footer.js`](diffhunk://#diff-74e01d50cd78ddfc2803667b5519893dc5ce55e80ade18accb9e06ed964bf6b4R32-R35): Added a "View Source" link to the footer, linking to the GitHub repository.

### Code Cleanup:
* [`theme/src/components/widgets/goodreads/book-explorer.js`](diffhunk://#diff-d7a562556f2d094f9e9f8de1b56986d8738f342cbcb774f651232011e1618c3dL123): Removed the `rel='noopener noreferrer'` attribute from the external link in the `BookExplorer` component.
* [`theme/src/components/widgets/goodreads/book-explorer.spec.js`](diffhunk://#diff-488e04da62e3b99b50865f4248a7f0d213247c49712bb48223e8e50a7da5c919L99): Updated the test to ensure the external link no longer includes `rel='noopener noreferrer'`.
* [`theme/src/components/widgets/instagram/instagram-widget-item.js`](diffhunk://#diff-2933ebab7842e24dca846ac4d05428d6c07932e608a968022dbe11bc2eb93fdaL14): Removed the `rel='noopener noreferrer'` attribute from the Instagram widget button.
* [`theme/src/components/widgets/instagram/__snapshots__/instagram-widget-item.spec.js.snap`](diffhunk://#diff-82a4ac43a94914d4981c6ec18e4bad38fccaec1a4b0b389ff33bdeb5a0ef1686L7): Updated the snapshot to reflect the removal of `rel='noopener noreferrer'`.