### PR TITLE
chore: fixup all unit test warnings and logs

### DIFF
--- a/theme/src/components/widgets/goodreads/book-explorer.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.js
@@ -17,8 +17,6 @@ const BookExplorer = ({ book, onClose }) => {
   const { authors, cdnMediaURL, description, infoLink, rating, title } = book
   const location = useLocation()
 
-  console.log('BookExplorer rendered with book:', book)
-
   const handleBackClick = e => {
     e.preventDefault()
     onClose()

--- a/theme/src/components/widgets/goodreads/book-explorer.spec.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.spec.js
@@ -88,11 +88,6 @@ describe('Widget/Goodreads/BookExplorer', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('logs book details for debugging', () => {
-    renderWithRouter(<BookExplorer book={mockBook} onClose={() => {}} default />)
-    expect(console.log).toHaveBeenCalledWith('BookExplorer rendered with book:', mockBook)
-  })
-
   it('renders external link without target="_blank"', () => {
     renderWithRouter(<BookExplorer book={mockBook} onClose={() => {}} default />)
     const link = screen.getByText('Learn more on Google Books')

--- a/theme/src/components/widgets/goodreads/book-link.spec.js
+++ b/theme/src/components/widgets/goodreads/book-link.spec.js
@@ -64,11 +64,8 @@ describe('Widget/Goodreads/BookLink', () => {
   })
 
   it('logs click event details for debugging', async () => {
-    // Mock window.scrollY and location
+    // Mock window.scrollY
     Object.defineProperty(window, 'scrollY', { value: 200 })
-    const mockLocation = { pathname: '/', search: '' }
-    delete window.location
-    window.location = mockLocation
     render(<BookLink {...mockProps} />)
     const link = screen.getByTestId('book-link')
     fireEvent.click(link)

--- a/theme/src/components/widgets/goodreads/recently-read-books.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.js
@@ -38,7 +38,6 @@ const RecentlyReadBooks = ({ books = [], isLoading }) => {
     }
     // If we have a scroll position in state, restore it
     else if (location.state?.scrollPosition) {
-      console.log('Restoring scroll position:', location.state.scrollPosition)
       // Use requestAnimationFrame to ensure smooth restoration
       requestAnimationFrame(() => {
         window.scrollTo({

--- a/theme/src/components/widgets/goodreads/recently-read-books.spec.js
+++ b/theme/src/components/widgets/goodreads/recently-read-books.spec.js
@@ -64,10 +64,6 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
       mockGetElementById.mockClear()
       // Mock navigate function
       jest.spyOn(require('@gatsbyjs/reach-router'), 'navigate').mockImplementation(mockNavigate)
-      // Set window.location properties directly
-      window.location.hash = ''
-      window.location.pathname = '/'
-      window.location.search = ''
     })
 
     it('restores scroll position when location state contains scrollPosition', async () => {
@@ -141,10 +137,7 @@ describe('Widget/Goodreads/RecentlyReadBooks', () => {
     it('scrolls to goodreads element when bookId is present and no scroll state', async () => {
       const mockElement = { offsetHeight: 100 }
       mockGetElementById.mockReturnValue(mockElement)
-      // Set location for this test
-      window.location.hash = ''
-      window.location.pathname = '/'
-      window.location.search = '?bookId=123'
+      // No need to mock window.location properties; use JSDOM defaults
       render(
         <LocationProvider
           history={{


### PR DESCRIPTION
This PR resolves all unit test warnings and logs, to that running the tests is clean. ✅

This pull request focuses on cleaning up debugging code and simplifying test setups in the Goodreads widget components and their associated tests. The most important changes involve removing unnecessary `console.log` statements and redundant mocking of `window.location` properties.

### Removal of debugging code:

* [`theme/src/components/widgets/goodreads/book-explorer.js`](diffhunk://#diff-d7a562556f2d094f9e9f8de1b56986d8738f342cbcb774f651232011e1618c3dL20-L21): Removed a `console.log` statement that logged book details during the rendering of the `BookExplorer` component.
* [`theme/src/components/widgets/goodreads/recently-read-books.js`](diffhunk://#diff-23ef2e04f44b58a18d84a37a8fa53445a10b0243c0168d446001cca1705635d1L41): Removed a `console.log` statement that logged scroll position restoration details in the `RecentlyReadBooks` component.

### Simplification of test setups:

* [`theme/src/components/widgets/goodreads/book-explorer.spec.js`](diffhunk://#diff-488e04da62e3b99b50865f4248a7f0d213247c49712bb48223e8e50a7da5c919L91-L95): Removed a test that verified the presence of the now-deleted `console.log` statement in the `BookExplorer` component.
* [`theme/src/components/widgets/goodreads/book-link.spec.js`](diffhunk://#diff-e830cb6ff7de8656f2a4ad41be719457c53cf1f64553dfa84dd4e5d619102b23L67-L71): Simplified the test setup for the `BookLink` component by removing unnecessary mocking of `window.location` properties.
* [`theme/src/components/widgets/goodreads/recently-read-books.spec.js`](diffhunk://#diff-58367cd3c4556ed027207dab4a18fbc878c85aa75cb29770f927c15584bf06d5L67-L70): Simplified tests for the `RecentlyReadBooks` component by removing redundant mocking of `window.location` properties and relying on JSDOM defaults. [[1]](diffhunk://#diff-58367cd3c4556ed027207dab4a18fbc878c85aa75cb29770f927c15584bf06d5L67-L70) [[2]](diffhunk://#diff-58367cd3c4556ed027207dab4a18fbc878c85aa75cb29770f927c15584bf06d5L144-R140)