### PR TITLE
feat: [v0.43.0] cleanup blog post index page

### DIFF
--- a/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
+++ b/theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap
@@ -1,6 +1,6 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`PostCard matches the snapshot 1`] = `
+exports[`PostCard does not render excerpt when explicitly null 1`] = `
 <a
   className="css-sod6qt"
   href="/blog/article"
@@ -24,6 +24,199 @@ exports[`PostCard matches the snapshot 1`] = `
         className="css-1blzwpa"
       >
         Personal
+      </div>
+      <h3
+        className="css-13imqch"
+      >
+        My Blog Post
+      </h3>
+      <time
+        className="created css-1c6hy0j"
+      >
+        1592202624
+      </time>
+    </div>
+  </div>
+</a>
+`;
+
+exports[`PostCard does not render excerpt when explicitly undefined 1`] = `
+<a
+  className="css-sod6qt"
+  href="/blog/article"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="css-139dwiw"
+  >
+    <div
+      className="card-content css-x4n4mc"
+    >
+      <div
+        className="card-media"
+      >
+        <div
+          className="css-1hpd2dn"
+        />
+      </div>
+      <div
+        className="css-1blzwpa"
+      >
+        Personal
+      </div>
+      <h3
+        className="css-13imqch"
+      >
+        My Blog Post
+      </h3>
+      <time
+        className="created css-1c6hy0j"
+      >
+        1592202624
+      </time>
+    </div>
+  </div>
+</a>
+`;
+
+exports[`PostCard matches the snapshot without excerpt 1`] = `
+<a
+  className="css-sod6qt"
+  href="/blog/article"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="css-139dwiw"
+  >
+    <div
+      className="card-content css-x4n4mc"
+    >
+      <div
+        className="card-media"
+      >
+        <div
+          className="css-1hpd2dn"
+        />
+      </div>
+      <div
+        className="css-1blzwpa"
+      >
+        Personal
+      </div>
+      <h3
+        className="css-13imqch"
+      >
+        My Blog Post
+      </h3>
+      <time
+        className="created css-1c6hy0j"
+      >
+        1592202624
+      </time>
+    </div>
+  </div>
+</a>
+`;
+
+exports[`PostCard renders excerpt when provided 1`] = `
+<a
+  className="css-sod6qt"
+  href="/blog/article"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="css-139dwiw"
+  >
+    <div
+      className="card-content css-x4n4mc"
+    >
+      <div
+        className="card-media"
+      >
+        <div
+          className="css-1hpd2dn"
+        />
+      </div>
+      <div
+        className="css-1blzwpa"
+      >
+        Personal
+      </div>
+      <h3
+        className="css-13imqch"
+      >
+        My Blog Post
+      </h3>
+      <time
+        className="created css-1c6hy0j"
+      >
+        1592202624
+      </time>
+      <p
+        className="description css-1uz48mf"
+      >
+        This is a sample excerpt for the blog post.
+      </p>
+    </div>
+  </div>
+</a>
+`;
+
+exports[`PostCard renders without banner when not provided 1`] = `
+<a
+  className="css-sod6qt"
+  href="/blog/article"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="css-139dwiw"
+  >
+    <div
+      className="card-content css-x4n4mc"
+    >
+      <div
+        className="css-1blzwpa"
+      >
+        Personal
+      </div>
+      <h3
+        className="css-13imqch"
+      >
+        My Blog Post
+      </h3>
+      <time
+        className="created css-1c6hy0j"
+      >
+        1592202624
+      </time>
+    </div>
+  </div>
+</a>
+`;
+
+exports[`PostCard renders without category when not provided 1`] = `
+<a
+  className="css-sod6qt"
+  href="/blog/article"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+>
+  <div
+    className="css-139dwiw"
+  >
+    <div
+      className="card-content css-x4n4mc"
+    >
+      <div
+        className="card-media"
+      >
+        <div
+          className="css-1hpd2dn"
+        />
       </div>
       <h3
         className="css-13imqch"

--- a/theme/src/components/widgets/recent-posts/post-card.spec.js
+++ b/theme/src/components/widgets/recent-posts/post-card.spec.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer'
 import PostCard from './post-card'
 
 describe('PostCard', () => {
-  const props = {
+  const baseProps = {
     banner: 'https://cdn.chrisvogt.me/images/article-og-banner.jpg',
     category: 'personal',
     date: '1592202624',
@@ -11,8 +11,106 @@ describe('PostCard', () => {
     title: 'My Blog Post'
   }
 
-  it('matches the snapshot', () => {
-    const tree = renderer.create(<PostCard {...props} />).toJSON()
+  it('matches the snapshot without excerpt', () => {
+    const tree = renderer.create(<PostCard {...baseProps} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  it('renders excerpt when provided', () => {
+    const propsWithExcerpt = {
+      ...baseProps,
+      excerpt: 'This is a sample excerpt for the blog post.'
+    }
+    const tree = renderer.create(<PostCard {...propsWithExcerpt} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('does not render excerpt when explicitly null', () => {
+    const propsWithNullExcerpt = {
+      ...baseProps,
+      excerpt: null
+    }
+    const tree = renderer.create(<PostCard {...propsWithNullExcerpt} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('does not render excerpt when explicitly undefined', () => {
+    const propsWithUndefinedExcerpt = {
+      ...baseProps,
+      excerpt: undefined
+    }
+    const tree = renderer.create(<PostCard {...propsWithUndefinedExcerpt} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders without banner when not provided', () => {
+    const propsWithoutBanner = {
+      category: 'personal',
+      date: '1592202624',
+      link: '/blog/article',
+      title: 'My Blog Post'
+    }
+    const tree = renderer.create(<PostCard {...propsWithoutBanner} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders without category when not provided', () => {
+    const propsWithoutCategory = {
+      banner: 'https://cdn.chrisvogt.me/images/article-og-banner.jpg',
+      date: '1592202624',
+      link: '/blog/article',
+      title: 'My Blog Post'
+    }
+    const tree = renderer.create(<PostCard {...propsWithoutCategory} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('specifically tests excerpt prop handling for blog page change', () => {
+    // This test specifically addresses the user's change where excerpt was commented out
+    const propsWithoutExcerpt = {
+      ...baseProps
+      // excerpt is intentionally not included, simulating the commented out line
+    }
+
+    const component = renderer.create(<PostCard {...propsWithoutExcerpt} />)
+    const tree = component.toJSON()
+
+    // Verify that no excerpt paragraph is rendered
+    const excerptParagraph = findExcerptParagraph(tree)
+    expect(excerptParagraph).toBeNull()
+
+    // Verify that the component still renders correctly without excerpt
+    expect(tree).toBeTruthy()
+  })
+
+  it('verifies excerpt is rendered when explicitly provided', () => {
+    const propsWithExcerpt = {
+      ...baseProps,
+      excerpt: 'This is a test excerpt that should be displayed.'
+    }
+
+    const component = renderer.create(<PostCard {...propsWithExcerpt} />)
+    const tree = component.toJSON()
+
+    // Verify that excerpt paragraph is rendered
+    const excerptParagraph = findExcerptParagraph(tree)
+    expect(excerptParagraph).toBeTruthy()
+    expect(excerptParagraph.children).toContain('This is a test excerpt that should be displayed.')
+  })
 })
+
+// Helper function to find the excerpt paragraph in the rendered tree
+function findExcerptParagraph(tree) {
+  if (!tree || !tree.children) return null
+
+  for (const child of tree.children) {
+    if (child.type === 'p' && child.props && child.props.className && child.props.className.includes('description')) {
+      return child
+    }
+    if (child.children) {
+      const found = findExcerptParagraph(child)
+      if (found) return found
+    }
+  }
+  return null
+}

--- a/www.chrisvogt.me/src/pages/blog.js
+++ b/www.chrisvogt.me/src/pages/blog.js
@@ -41,7 +41,7 @@ const BlogIndexPage = ({ data }) => {
               <PostCard
                 category={post.fields.category}
                 date={post.frontmatter.date}
-                excerpt={post.excerpt}
+                // excerpt={post.excerpt}
                 key={post.fields.id}
                 link={post.fields.path}
                 title={post.frontmatter.title}


### PR DESCRIPTION
This PR simplifies the Blog post index page by removing the excerpt from each post.

| Before | After |
|--------|-------|
|     <img width="1810" alt="post-before" src="https://github.com/user-attachments/assets/ba1b29ff-5fad-4b6b-9398-f9eb20888fae" />   |    <img width="1810" alt="post-after" src="https://github.com/user-attachments/assets/e4acc85d-dd0f-47d2-99ee-c36b3bbdaa43" />   |

## AI-generated sumary

This pull request introduces updates to the `PostCard` component and its related test suite, focusing on improving snapshot testing and handling of the `excerpt` prop. Additionally, it modifies the `BlogIndexPage` to temporarily remove the `excerpt` prop from the `PostCard` component. The changes aim to enhance test coverage and ensure consistent rendering behavior.

### Updates to `PostCard` component and tests:

#### Snapshot testing improvements:
* Updated `theme/src/components/widgets/recent-posts/__snapshots__/post-card.spec.js.snap` to include new snapshots for various rendering scenarios, such as when `excerpt` is null, undefined, or explicitly provided. Added additional snapshots for cases where `banner` or `category` are not provided. [[1]](diffhunk://#diff-883e28ac1b21fd79cf32e930d13f6ce8089d104330a9929c10cafb9d445a9f2dL1-R3) [[2]](diffhunk://#diff-883e28ac1b21fd79cf32e930d13f6ce8089d104330a9929c10cafb9d445a9f2dR42-R234)

#### Test suite enhancements:
* Refactored `theme/src/components/widgets/recent-posts/post-card.spec.js` to include new test cases covering different `PostCard` rendering scenarios. These include handling of the `excerpt` prop, absence of `banner` or `category`, and specific tests for ensuring correct rendering behavior when the `excerpt` is commented out. Introduced a helper function `findExcerptParagraph` for validating the presence of the excerpt in the rendered output.

### Changes to `BlogIndexPage`:

* Modified `www.chrisvogt.me/src/pages/blog.js` to temporarily comment out the `excerpt` prop passed to the `PostCard` component, likely as part of debugging or testing changes to the `PostCard` behavior.