### PR TITLE
feat: adds a new Owned Games section to the Steam widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.43.0
+
+- Adds a new Owned Games section to the Steam widget, using data added to metrics.chrisvogt.me via [chrisvogt/metrics#57](https://github.com/chrisvogt/metrics/pull/57).
+
+### Notes
+
+- The current <Table/> styles don't have a dark mode.

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.42.2",
+  "version": "0.43.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/steam/README.md
+++ b/theme/src/components/widgets/steam/README.md
@@ -1,0 +1,117 @@
+# Steam Widget
+
+The Steam widget displays information about a user's Steam profile, including recently played games and owned games.
+
+## Features
+
+### My Games Section
+
+- Displays a table of all owned games
+- Shows game icons, names, and play time statistics
+- Links to Steam store pages for each game
+- Uses Theme UI table styles for consistent styling
+
+### Recently-Played Games Section
+
+- Shows games played in the last two weeks
+- Displays game cards with headers and play time
+- Grid layout for responsive design
+
+## Components
+
+### SteamWidget
+
+Main widget component that orchestrates the display of Steam data.
+
+**Props:** None (uses Redux store for data)
+
+**Features:**
+
+- Fetches Steam data from configured data source
+- Displays profile metrics
+- Shows both owned games table and recently played games
+- Handles loading states
+
+### OwnedGamesTable
+
+Table component for displaying owned games.
+
+**Props:**
+
+- `games` (Array): Array of game objects from Steam API
+
+**Features:**
+
+- Responsive table layout
+- Game icons and names with links
+- Total and recent play time display
+- Empty state handling
+
+## Data Structure
+
+The widget expects Steam API data in the following format:
+
+```javascript
+{
+  metrics: [...],
+  profile: {
+    displayName: string,
+    profileURL: string
+  },
+  collections: {
+    recentlyPlayedGames: [
+      {
+        id: number,
+        displayName: string,
+        playTime2Weeks: number,
+        images: {
+          header: string
+        }
+      }
+    ],
+    ownedGames: [
+      {
+        id: number,
+        displayName: string,
+        playTimeForever: number,
+        playTime2Weeks: number | null,
+        images: {
+          icon: string
+        }
+      }
+    ]
+  }
+}
+```
+
+## Usage
+
+The Steam widget is automatically included in the home page when a Steam data source is configured in the site metadata.
+
+To configure the Steam widget, add the following to your `gatsby-config.js`:
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-theme-chrisvogt',
+      options: {
+        widgets: {
+          steam: {
+            widgetDataSource: 'https://your-steam-api-endpoint.com'
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## Styling
+
+The widget uses Theme UI for styling and includes:
+
+- Responsive grid layouts
+- Consistent table styling
+- Hover effects on interactive elements
+- Dark/light mode support

--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -32,24 +32,15 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
             className="css-1mawu4u"
             href="https://store.steampowered.com/app/255710"
             rel="noopener noreferrer"
-            target="_blank"
           >
             Cities: Skylines
           </a>
         </div>
       </td>
       <td>
-        <b>
-          Time Spent:
-        </b>
-         
-        1 month, 1 day, 2 hours, 51 minutes
+        757 hours
       </td>
       <td>
-        <b>
-          Time Spent:
-        </b>
-         
         2 hours
       </td>
     </tr>
@@ -67,18 +58,13 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
             className="css-1mawu4u"
             href="https://store.steampowered.com/app/346110"
             rel="noopener noreferrer"
-            target="_blank"
           >
             ARK: Survival Evolved
           </a>
         </div>
       </td>
       <td>
-        <b>
-          Time Spent:
-        </b>
-         
-        1 week, 4 days, 13 hours, 50 minutes
+        278 hours
       </td>
       <td>
         <span
@@ -108,12 +94,4 @@ exports[`OwnedGamesTable renders empty state when no games provided 1`] = `
 </p>
 `;
 
-exports[`TimeSpent renders humanized time correctly 1`] = `
-[
-  <b>
-    Time Spent:
-  </b>,
-  " ",
-  "5 minutes",
-]
-`;
+exports[`TimeSpent renders humanized time correctly 1`] = `"0 hours"`;

--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`OwnedGamesTable renders correctly with sample data 1`] = `
+<table
+  className="css-zezy6m"
+>
+  <thead>
+    <tr>
+      <th>
+        Game
+      </th>
+      <th>
+        Total Play Time
+      </th>
+      <th>
+        Recent Play Time
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <div
+          className="css-b0fne7"
+        >
+          <img
+            alt="Cities: Skylines icon"
+            className="css-sfnjuk"
+            src="https://example.com/cities-icon.jpg"
+          />
+          <a
+            className="css-1mawu4u"
+            href="https://store.steampowered.com/app/255710"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Cities: Skylines
+          </a>
+        </div>
+      </td>
+      <td>
+        <b>
+          Time Spent:
+        </b>
+         
+        1 month, 1 day, 2 hours, 51 minutes
+      </td>
+      <td>
+        <b>
+          Time Spent:
+        </b>
+         
+        2 hours
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <div
+          className="css-b0fne7"
+        >
+          <img
+            alt="ARK: Survival Evolved icon"
+            className="css-sfnjuk"
+            src="https://example.com/ark-icon.jpg"
+          />
+          <a
+            className="css-1mawu4u"
+            href="https://store.steampowered.com/app/346110"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            ARK: Survival Evolved
+          </a>
+        </div>
+      </td>
+      <td>
+        <b>
+          Time Spent:
+        </b>
+         
+        1 week, 4 days, 13 hours, 50 minutes
+      </td>
+      <td>
+        <span
+          className="css-tv4nyw"
+        >
+          Not played recently
+        </span>
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`OwnedGamesTable renders empty state when games is null 1`] = `
+<p
+  className="css-1mkkd6c"
+>
+  No owned games found.
+</p>
+`;
+
+exports[`OwnedGamesTable renders empty state when no games provided 1`] = `
+<p
+  className="css-1mkkd6c"
+>
+  No owned games found.
+</p>
+`;
+
+exports[`TimeSpent renders humanized time correctly 1`] = `
+[
+  <b>
+    Time Spent:
+  </b>,
+  " ",
+  "5 minutes",
+]
+`;

--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -68,9 +68,9 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
       </td>
       <td>
         <span
-          className="css-tv4nyw"
+          className="css-1nxn0wh"
         >
-          Not played recently
+          –
         </span>
       </td>
     </tr>

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SteamWidget renders correctly with sample data 1`] = `
 <div
@@ -15,7 +15,26 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
     [{"label":"Games Played","value":5}]
   </div>
   <div
-    className="css-ccroti"
+    className="css-gavibk"
+  >
+    <h3
+      className="css-1pgqsji"
+    >
+      My Games
+    </h3>
+  </div>
+  <p
+    className="css-1v9l0er"
+  >
+    Games I own and their play time statistics.
+  </p>
+  <div
+    data-testid="OwnedGamesTable"
+  >
+    [{"id":"255710","displayName":"Cities: Skylines","playTimeForever":45441,"playTime2Weeks":120,"images":{"icon":"https://example.com/cities-icon.jpg"}},{"id":"346110","displayName":"ARK: Survival Evolved","playTimeForever":16670,"playTime2Weeks":null,"images":{"icon":"https://example.com/ark-icon.jpg"}}]
+  </div>
+  <div
+    className="css-19lpcf0"
   >
     <h3
       className="css-1pgqsji"
@@ -24,7 +43,7 @@ exports[`SteamWidget renders correctly with sample data 1`] = `
     </h3>
   </div>
   <p
-    className="css-1avyp1d"
+    className="css-1v9l0er"
   >
     Games I've played in the last two weeks.
   </p>
@@ -60,7 +79,26 @@ exports[`SteamWidget renders loading state 1`] = `
     []
   </div>
   <div
-    className="css-ccroti"
+    className="css-gavibk"
+  >
+    <h3
+      className="css-1pgqsji"
+    >
+      My Games
+    </h3>
+  </div>
+  <p
+    className="css-1v9l0er"
+  >
+    Games I own and their play time statistics.
+  </p>
+  <div
+    data-testid="OwnedGamesTable"
+  >
+    []
+  </div>
+  <div
+    className="css-19lpcf0"
   >
     <h3
       className="css-1pgqsji"
@@ -69,7 +107,7 @@ exports[`SteamWidget renders loading state 1`] = `
     </h3>
   </div>
   <p
-    className="css-1avyp1d"
+    className="css-1v9l0er"
   >
     Games I've played in the last two weeks.
   </p>

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -117,12 +117,4 @@ exports[`SteamWidget renders loading state 1`] = `
 </div>
 `;
 
-exports[`TimeSpent renders humanized time correctly 1`] = `
-[
-  <b>
-    Time Spent:
-  </b>,
-  " ",
-  "5 minutes",
-]
-`;
+exports[`TimeSpent renders humanized time correctly 1`] = `"0 hours"`;

--- a/theme/src/components/widgets/steam/owned-games-table.js
+++ b/theme/src/components/widgets/steam/owned-games-table.js
@@ -68,7 +68,7 @@ const OwnedGamesTable = ({ games = [] }) => {
               {game.playTime2Weeks ? (
                 <TimeSpent timeInMs={game.playTime2Weeks * 60 * 1000} />
               ) : (
-                <span sx={{ color: 'textMuted', fontStyle: 'italic' }}>Not played recently</span>
+                <span sx={{ color: 'tableText', fontStyle: 'italic' }}>–</span>
               )}
             </td>
           </tr>

--- a/theme/src/components/widgets/steam/owned-games-table.js
+++ b/theme/src/components/widgets/steam/owned-games-table.js
@@ -1,0 +1,76 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import { Fragment } from 'react'
+import { Themed } from '@theme-ui/mdx'
+import humanizeDuration from 'humanize-duration'
+
+export const TimeSpent = ({ timeInMs }) => (
+  <Fragment>{humanizeDuration(timeInMs, { units: ['h'], round: true })}</Fragment>
+)
+
+const OwnedGamesTable = ({ games = [] }) => {
+  if (!games || games.length === 0) {
+    return (
+      <Themed.p sx={{ textAlign: 'center', fontStyle: 'italic', color: 'textMuted' }}>No owned games found.</Themed.p>
+    )
+  }
+
+  return (
+    <Themed.table sx={{ variant: 'styles.table' }}>
+      <thead>
+        <tr>
+          <th>Game</th>
+          <th>Total Play Time</th>
+          <th>Recent Play Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        {games.map(game => (
+          <tr key={game.id}>
+            <td>
+              <div sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                <img
+                  src={game.images?.icon}
+                  alt={`${game.displayName} icon`}
+                  sx={{
+                    width: '32px',
+                    height: '32px',
+                    borderRadius: '4px',
+                    objectFit: 'cover'
+                  }}
+                />
+                <a
+                  href={`https://store.steampowered.com/app/${game.id}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  sx={{
+                    color: 'primary',
+                    textDecoration: 'none',
+                    fontWeight: 'medium',
+                    '&:hover': {
+                      textDecoration: 'underline'
+                    }
+                  }}
+                >
+                  {game.displayName}
+                </a>
+              </div>
+            </td>
+            <td>
+              <TimeSpent timeInMs={game.playTimeForever * 60 * 1000} />
+            </td>
+            <td>
+              {game.playTime2Weeks ? (
+                <TimeSpent timeInMs={game.playTime2Weeks * 60 * 1000} />
+              ) : (
+                <span sx={{ color: 'textMuted', fontStyle: 'italic' }}>Not played recently</span>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Themed.table>
+  )
+}
+
+export default OwnedGamesTable

--- a/theme/src/components/widgets/steam/owned-games-table.js
+++ b/theme/src/components/widgets/steam/owned-games-table.js
@@ -4,6 +4,8 @@ import { Fragment } from 'react'
 import { Themed } from '@theme-ui/mdx'
 import humanizeDuration from 'humanize-duration'
 
+import ViewExternal from '../view-external'
+
 export const TimeSpent = ({ timeInMs }) => (
   <Fragment>{humanizeDuration(timeInMs, { units: ['h'], round: true })}</Fragment>
 )
@@ -15,6 +17,10 @@ const OwnedGamesTable = ({ games = [] }) => {
     )
   }
 
+  const totalGames = games.length
+  const displayedGames = games.slice(0, 10) // Show first 10 games
+  const remainingGames = totalGames - displayedGames.length
+
   return (
     <Themed.table sx={{ variant: 'styles.table' }}>
       <thead>
@@ -25,7 +31,7 @@ const OwnedGamesTable = ({ games = [] }) => {
         </tr>
       </thead>
       <tbody>
-        {games.map(game => (
+        {displayedGames.map(game => (
           <tr key={game.id}>
             <td>
               <div sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
@@ -41,7 +47,6 @@ const OwnedGamesTable = ({ games = [] }) => {
                 />
                 <a
                   href={`https://store.steampowered.com/app/${game.id}`}
-                  target='_blank'
                   rel='noopener noreferrer'
                   sx={{
                     color: 'primary',
@@ -68,6 +73,30 @@ const OwnedGamesTable = ({ games = [] }) => {
             </td>
           </tr>
         ))}
+        {remainingGames > 0 && (
+          <tr>
+            <td colSpan={3} sx={{ textAlign: 'center', padding: '16px' }}>
+              <a
+                href='https://steamcommunity.com/id/chrisvogt/games/?tab=all'
+                rel='noopener noreferrer'
+                sx={{
+                  color: 'primary',
+                  textDecoration: 'none',
+                  fontWeight: 'medium',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  '&:hover': {
+                    textDecoration: 'underline'
+                  }
+                }}
+              >
+                ...and {remainingGames} other game{remainingGames !== 1 ? 's' : ''}
+                <ViewExternal />
+              </a>
+            </td>
+          </tr>
+        )}
       </tbody>
     </Themed.table>
   )

--- a/theme/src/components/widgets/steam/owned-games-table.spec.js
+++ b/theme/src/components/widgets/steam/owned-games-table.spec.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import OwnedGamesTable, { TimeSpent } from './owned-games-table'
+
+describe('OwnedGamesTable', () => {
+  it('renders correctly with sample data', () => {
+    const sampleGames = [
+      {
+        id: 255710,
+        displayName: 'Cities: Skylines',
+        playTimeForever: 45441,
+        playTime2Weeks: 120,
+        images: {
+          icon: 'https://example.com/cities-icon.jpg'
+        }
+      },
+      {
+        id: 346110,
+        displayName: 'ARK: Survival Evolved',
+        playTimeForever: 16670,
+        playTime2Weeks: null,
+        images: {
+          icon: 'https://example.com/ark-icon.jpg'
+        }
+      }
+    ]
+
+    const tree = renderer.create(<OwnedGamesTable games={sampleGames} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders empty state when no games provided', () => {
+    const tree = renderer.create(<OwnedGamesTable games={[]} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders empty state when games is null', () => {
+    const tree = renderer.create(<OwnedGamesTable games={null} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})
+
+describe('TimeSpent', () => {
+  it('renders humanized time correctly', () => {
+    const tree = renderer.create(<TimeSpent timeInMs={5 * 60 * 1000} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -13,6 +13,7 @@ import PostCard from '../recent-posts/post-card'
 import ProfileMetricsBadge from '../profile-metrics-badge'
 import Widget from '../widget'
 import WidgetHeader from '../widget-header'
+import OwnedGamesTable from './owned-games-table'
 
 import { SUCCESS } from '../../../reducers/widgets'
 import fetchDataSource from '../../../actions/fetchDataSource'
@@ -20,9 +21,7 @@ import { getSteamWidgetDataSource } from '../../../selectors/metadata'
 import useSiteMetadata from '../../../hooks/use-site-metadata'
 
 export const TimeSpent = ({ timeInMs }) => (
-  <Fragment>
-    <b>Time Spent:</b> {humanizeDuration(timeInMs)}
-  </Fragment>
+  <Fragment>{humanizeDuration(timeInMs, { units: ['h'], round: true })}</Fragment>
 )
 
 const EMPTY_ARRAY = []
@@ -43,6 +42,7 @@ const SteamWidget = () => {
   const recentlyPlayedGames = useSelector(
     state => get(state, 'widgets.steam.data.collections.recentlyPlayedGames') ?? EMPTY_ARRAY
   )
+  const ownedGames = useSelector(state => get(state, 'widgets.steam.data.collections.ownedGames') ?? EMPTY_ARRAY)
 
   const callToAction = (
     <CallToAction title={`${profileDisplayName} on Steam`} url={profileURL} isLoading={isLoading}>
@@ -59,13 +59,25 @@ const SteamWidget = () => {
 
       <ProfileMetricsBadge isLoading={isLoading} metrics={metrics} />
 
-      <div sx={{ display: 'flex', flex: 1, alignItems: 'center' }}>
+      {/* My Games Section */}
+      <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mb: 3 }}>
+        <Heading as='h3' sx={{ fontSize: [3, 4] }}>
+          My Games
+        </Heading>
+      </div>
+
+      <Themed.p sx={{ mb: 4 }}>Games I own and their play time statistics.</Themed.p>
+
+      <OwnedGamesTable games={ownedGames.slice(0, 8)} />
+
+      {/* Recently-Played Games Section */}
+      <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mt: 5, mb: 3 }}>
         <Heading as='h3' sx={{ fontSize: [3, 4] }}>
           Recently-Played Games
         </Heading>
       </div>
 
-      <Themed.p>Games I've played in the last two weeks.</Themed.p>
+      <Themed.p sx={{ mb: 4 }}>Games I've played in the last two weeks.</Themed.p>
 
       <div
         sx={{

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -68,7 +68,7 @@ const SteamWidget = () => {
 
       <Themed.p sx={{ mb: 4 }}>Games I own and their play time statistics.</Themed.p>
 
-      <OwnedGamesTable games={ownedGames.slice(0, 8)} />
+      <OwnedGamesTable games={ownedGames} />
 
       {/* Recently-Played Games Section */}
       <div sx={{ display: 'flex', flex: 1, alignItems: 'center', mt: 5, mb: 3 }}>

--- a/theme/src/components/widgets/steam/steam-widget.spec.js
+++ b/theme/src/components/widgets/steam/steam-widget.spec.js
@@ -12,6 +12,7 @@ jest.mock('../profile-metrics-badge', () => props => (
 ))
 jest.mock('../widget', () => props => <div data-testid='Widget'>{props.children}</div>)
 jest.mock('../widget-header', () => props => <div data-testid='WidgetHeader'>{props.children}</div>)
+jest.mock('./owned-games-table', () => props => <div data-testid='OwnedGamesTable'>{JSON.stringify(props.games)}</div>)
 
 // Mock hooks and selectors
 jest.mock('../../../hooks/use-site-metadata', () => () => ({
@@ -49,6 +50,22 @@ describe('SteamWidget', () => {
                   displayName: 'Portal',
                   playTime2Weeks: 45,
                   images: { header: 'https://example.com/portal.jpg' }
+                }
+              ],
+              ownedGames: [
+                {
+                  id: '255710',
+                  displayName: 'Cities: Skylines',
+                  playTimeForever: 45441,
+                  playTime2Weeks: 120,
+                  images: { icon: 'https://example.com/cities-icon.jpg' }
+                },
+                {
+                  id: '346110',
+                  displayName: 'ARK: Survival Evolved',
+                  playTimeForever: 16670,
+                  playTime2Weeks: null,
+                  images: { icon: 'https://example.com/ark-icon.jpg' }
                 }
               ]
             }


### PR DESCRIPTION
This PR adds a new table to the Steam widget on the Home page that shows my games in descending order of how much time I've spent playing each.

<img width="1729" alt="Screenshot 2025-06-18 at 10 37 40 PM" src="https://github.com/user-attachments/assets/c4e592ea-4d83-4da5-8b40-bd7c3ad02153" />

## AI summary

This pull request introduces a new "Owned Games" section to the Steam widget, updates associated tests and documentation, and improves the Steam widget's functionality and styling. The changes primarily focus on enhancing the user experience by displaying owned games with detailed statistics and ensuring seamless integration with the existing widget structure.

### Steam Widget Enhancements:
* Added a new "Owned Games" section to the Steam widget, displaying a table of owned games with icons, names, play time statistics, and links to Steam store pages. This section is styled using Theme UI and handles empty states gracefully. (`theme/src/components/widgets/steam/owned-games-table.js` - [[1]](diffhunk://#diff-3abde98fe1344b271a0f9e8d4da14e9472195fee3d73e35d44252205266e1bfbR1-R105) `theme/src/components/widgets/steam/steam-widget.js` - [[2]](diffhunk://#diff-3d1e44016f066a4914eed1075686a89f04ab8f8bdfea0862aef56201d411d528R45) [[3]](diffhunk://#diff-3d1e44016f066a4914eed1075686a89f04ab8f8bdfea0862aef56201d411d528L62-R80)
* Updated the Steam widget tests to include snapshots for the "Owned Games" section, verifying correct rendering with sample data, empty states, and loading states. (`theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap` - [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eR1-R97) `theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap` - [[2]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L1-R1)R1, [[3]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L18-R37) [[4]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L27-R46) [[5]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L63-R101) [[6]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L72-R110) [[7]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L82-R120)

### Documentation Updates:
* Added a detailed README for the Steam widget, outlining its features, components, data structure, styling, and usage instructions. (`theme/src/components/widgets/steam/README.md` - [theme/src/components/widgets/steam/README.mdR1-R117](diffhunk://#diff-642992b3731e668dc5cd39b00141e9a1fe1972e039ef77098f0c9685767eeae2R1-R117))

### Testing Improvements:
* Created new unit tests for the `OwnedGamesTable` component and its helper function `TimeSpent`, ensuring accurate rendering and functionality. (`theme/src/components/widgets/steam/owned-games-table.spec.js` - [theme/src/components/widgets/steam/owned-games-table.spec.jsR1-R48](diffhunk://#diff-92f9a675f4e343f281712726d17e26ce727f6b9899a48497ab1b83a27664b438R1-R48))
* Mocked the `OwnedGamesTable` in Steam widget tests to validate its integration and data handling. (`theme/src/components/widgets/steam/steam-widget.spec.js` - [[1]](diffhunk://#diff-a0fedc93840595ccb97eb1fd1830c36035894882c3d458d20d705e59ec030155R15) [[2]](diffhunk://#diff-a0fedc93840595ccb97eb1fd1830c36035894882c3d458d20d705e59ec030155R54-R69)

### Versioning and Changelog:
* Updated the package version to `0.43.0` and added changelog entries describing the new "Owned Games" section and its dependency on external metrics data. (`theme/package.json` - [[1]](diffhunk://#diff-864251b807b1925eadafb797a61b4fb855065215fc4e7129a00ec23a2dd4ed72L4-R4) `CHANGELOG.md` - [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R9)