### PR TITLE
feat: add dark mode to <table /> element styles

### DIFF
--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singular "other game" 1`] = `
 <table
-  className="css-8qs8w"
+  className="css-1intvy2"
 >
   <thead>
     <tr>
@@ -339,7 +339,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
 
 exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plural "other games" 1`] = `
 <table
-  className="css-8qs8w"
+  className="css-1intvy2"
 >
   <thead>
     <tr>
@@ -677,7 +677,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
 
 exports[`OwnedGamesTable renders correctly with more than 10 games and shows remaining games section 1`] = `
 <table
-  className="css-8qs8w"
+  className="css-1intvy2"
 >
   <thead>
     <tr>
@@ -1015,7 +1015,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
 
 exports[`OwnedGamesTable renders correctly with sample data 1`] = `
 <table
-  className="css-8qs8w"
+  className="css-1intvy2"
 >
   <thead>
     <tr>

--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singular "other game" 1`] = `
 <table
-  className="css-zezy6m"
+  className="css-8qs8w"
 >
   <thead>
     <tr>
@@ -21,7 +21,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 1 icon"
@@ -29,7 +29,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-1-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100000"
             rel="noopener noreferrer"
           >
@@ -47,7 +47,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 2 icon"
@@ -55,7 +55,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-2-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100001"
             rel="noopener noreferrer"
           >
@@ -68,7 +68,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -77,7 +77,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 3 icon"
@@ -85,7 +85,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-3-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100002"
             rel="noopener noreferrer"
           >
@@ -103,7 +103,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 4 icon"
@@ -111,7 +111,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-4-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100003"
             rel="noopener noreferrer"
           >
@@ -124,7 +124,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -133,7 +133,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 5 icon"
@@ -141,7 +141,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-5-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100004"
             rel="noopener noreferrer"
           >
@@ -159,7 +159,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 6 icon"
@@ -167,7 +167,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-6-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100005"
             rel="noopener noreferrer"
           >
@@ -180,7 +180,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -189,7 +189,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 7 icon"
@@ -197,7 +197,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-7-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100006"
             rel="noopener noreferrer"
           >
@@ -215,7 +215,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 8 icon"
@@ -223,7 +223,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-8-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100007"
             rel="noopener noreferrer"
           >
@@ -236,7 +236,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -245,7 +245,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 9 icon"
@@ -253,7 +253,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-9-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100008"
             rel="noopener noreferrer"
           >
@@ -271,7 +271,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 10 icon"
@@ -279,7 +279,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
             src="https://example.com/game-10-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100009"
             rel="noopener noreferrer"
           >
@@ -292,7 +292,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -304,7 +304,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         colSpan={3}
       >
         <a
-          className="css-1vh3e7c"
+          className="css-1lwlkan"
           href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
           rel="noopener noreferrer"
         >
@@ -339,7 +339,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
 
 exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plural "other games" 1`] = `
 <table
-  className="css-zezy6m"
+  className="css-8qs8w"
 >
   <thead>
     <tr>
@@ -358,7 +358,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 1 icon"
@@ -366,7 +366,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-1-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100000"
             rel="noopener noreferrer"
           >
@@ -384,7 +384,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 2 icon"
@@ -392,7 +392,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-2-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100001"
             rel="noopener noreferrer"
           >
@@ -405,7 +405,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -414,7 +414,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 3 icon"
@@ -422,7 +422,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-3-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100002"
             rel="noopener noreferrer"
           >
@@ -440,7 +440,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 4 icon"
@@ -448,7 +448,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-4-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100003"
             rel="noopener noreferrer"
           >
@@ -461,7 +461,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -470,7 +470,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 5 icon"
@@ -478,7 +478,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-5-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100004"
             rel="noopener noreferrer"
           >
@@ -496,7 +496,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 6 icon"
@@ -504,7 +504,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-6-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100005"
             rel="noopener noreferrer"
           >
@@ -517,7 +517,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -526,7 +526,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 7 icon"
@@ -534,7 +534,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-7-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100006"
             rel="noopener noreferrer"
           >
@@ -552,7 +552,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 8 icon"
@@ -560,7 +560,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-8-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100007"
             rel="noopener noreferrer"
           >
@@ -573,7 +573,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -582,7 +582,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 9 icon"
@@ -590,7 +590,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-9-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100008"
             rel="noopener noreferrer"
           >
@@ -608,7 +608,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 10 icon"
@@ -616,7 +616,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
             src="https://example.com/game-10-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100009"
             rel="noopener noreferrer"
           >
@@ -629,7 +629,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -641,7 +641,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         colSpan={3}
       >
         <a
-          className="css-1vh3e7c"
+          className="css-1lwlkan"
           href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
           rel="noopener noreferrer"
         >
@@ -677,7 +677,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
 
 exports[`OwnedGamesTable renders correctly with more than 10 games and shows remaining games section 1`] = `
 <table
-  className="css-zezy6m"
+  className="css-8qs8w"
 >
   <thead>
     <tr>
@@ -696,7 +696,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 1 icon"
@@ -704,7 +704,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-1-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100000"
             rel="noopener noreferrer"
           >
@@ -722,7 +722,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 2 icon"
@@ -730,7 +730,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-2-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100001"
             rel="noopener noreferrer"
           >
@@ -743,7 +743,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -752,7 +752,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 3 icon"
@@ -760,7 +760,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-3-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100002"
             rel="noopener noreferrer"
           >
@@ -778,7 +778,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 4 icon"
@@ -786,7 +786,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-4-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100003"
             rel="noopener noreferrer"
           >
@@ -799,7 +799,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -808,7 +808,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 5 icon"
@@ -816,7 +816,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-5-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100004"
             rel="noopener noreferrer"
           >
@@ -834,7 +834,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 6 icon"
@@ -842,7 +842,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-6-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100005"
             rel="noopener noreferrer"
           >
@@ -855,7 +855,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -864,7 +864,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 7 icon"
@@ -872,7 +872,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-7-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100006"
             rel="noopener noreferrer"
           >
@@ -890,7 +890,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 8 icon"
@@ -898,7 +898,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-8-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100007"
             rel="noopener noreferrer"
           >
@@ -911,7 +911,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -920,7 +920,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 9 icon"
@@ -928,7 +928,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-9-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100008"
             rel="noopener noreferrer"
           >
@@ -946,7 +946,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Game 10 icon"
@@ -954,7 +954,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
             src="https://example.com/game-10-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/100009"
             rel="noopener noreferrer"
           >
@@ -967,7 +967,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -979,7 +979,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         colSpan={3}
       >
         <a
-          className="css-1vh3e7c"
+          className="css-1lwlkan"
           href="https://steamcommunity.com/id/chrisvogt/games/?tab=all"
           rel="noopener noreferrer"
         >
@@ -1015,7 +1015,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
 
 exports[`OwnedGamesTable renders correctly with sample data 1`] = `
 <table
-  className="css-zezy6m"
+  className="css-8qs8w"
 >
   <thead>
     <tr>
@@ -1034,7 +1034,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="Cities: Skylines icon"
@@ -1042,7 +1042,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
             src="https://example.com/cities-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/255710"
             rel="noopener noreferrer"
           >
@@ -1060,7 +1060,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
     <tr>
       <td>
         <div
-          className="css-b0fne7"
+          className="css-uoday8"
         >
           <img
             alt="ARK: Survival Evolved icon"
@@ -1068,7 +1068,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
             src="https://example.com/ark-icon.jpg"
           />
           <a
-            className="css-1mawu4u"
+            className="css-rferrc"
             href="https://store.steampowered.com/app/346110"
             rel="noopener noreferrer"
           >
@@ -1081,7 +1081,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
       </td>
       <td>
         <span
-          className="css-1nxn0wh"
+          className="css-1ru781j"
         >
           –
         </span>
@@ -1093,7 +1093,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
 
 exports[`OwnedGamesTable renders empty state when games is null 1`] = `
 <p
-  className="css-1mkkd6c"
+  className="css-1fvqmuk"
 >
   No owned games found.
 </p>
@@ -1101,7 +1101,7 @@ exports[`OwnedGamesTable renders empty state when games is null 1`] = `
 
 exports[`OwnedGamesTable renders empty state when games is undefined 1`] = `
 <p
-  className="css-1mkkd6c"
+  className="css-1fvqmuk"
 >
   No owned games found.
 </p>
@@ -1109,7 +1109,7 @@ exports[`OwnedGamesTable renders empty state when games is undefined 1`] = `
 
 exports[`OwnedGamesTable renders empty state when no games provided 1`] = `
 <p
-  className="css-1mkkd6c"
+  className="css-1fvqmuk"
 >
   No owned games found.
 </p>

--- a/theme/src/components/widgets/steam/owned-games-table.js
+++ b/theme/src/components/widgets/steam/owned-games-table.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, useColorMode } from 'theme-ui'
 import { Fragment } from 'react'
 import { Themed } from '@theme-ui/mdx'
 import humanizeDuration from 'humanize-duration'
@@ -11,6 +11,9 @@ export const TimeSpent = ({ timeInMs }) => (
 )
 
 const OwnedGamesTable = ({ games = [] }) => {
+  const [colorMode] = useColorMode()
+  const tableVariant = colorMode === 'dark' ? 'styles.tableDark' : 'styles.table'
+
   if (!games || games.length === 0) {
     return (
       <Themed.p sx={{ textAlign: 'center', fontStyle: 'italic', color: 'textMuted' }}>No owned games found.</Themed.p>
@@ -22,7 +25,7 @@ const OwnedGamesTable = ({ games = [] }) => {
   const remainingGames = totalGames - displayedGames.length
 
   return (
-    <Themed.table sx={{ variant: 'styles.table' }}>
+    <Themed.table sx={{ variant: tableVariant }}>
       <thead>
         <tr>
           <th>Game</th>

--- a/theme/src/components/widgets/steam/owned-games-table.spec.js
+++ b/theme/src/components/widgets/steam/owned-games-table.spec.js
@@ -1,6 +1,12 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
+import { ThemeUIProvider } from 'theme-ui'
+import theme from '../../../gatsby-plugin-theme-ui'
 import OwnedGamesTable, { TimeSpent } from './owned-games-table'
+
+const renderWithColorMode = component => {
+  return renderer.create(<ThemeUIProvider theme={theme}>{component}</ThemeUIProvider>)
+}
 
 describe('OwnedGamesTable', () => {
   it('renders correctly with sample data', () => {
@@ -25,22 +31,22 @@ describe('OwnedGamesTable', () => {
       }
     ]
 
-    const tree = renderer.create(<OwnedGamesTable games={sampleGames} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={sampleGames} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
   it('renders empty state when no games provided', () => {
-    const tree = renderer.create(<OwnedGamesTable games={[]} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={[]} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
   it('renders empty state when games is null', () => {
-    const tree = renderer.create(<OwnedGamesTable games={null} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={null} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
   it('renders empty state when games is undefined', () => {
-    const tree = renderer.create(<OwnedGamesTable games={undefined} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={undefined} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
@@ -55,7 +61,7 @@ describe('OwnedGamesTable', () => {
       }
     }))
 
-    const tree = renderer.create(<OwnedGamesTable games={manyGames} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={manyGames} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
@@ -70,7 +76,7 @@ describe('OwnedGamesTable', () => {
       }
     }))
 
-    const tree = renderer.create(<OwnedGamesTable games={elevenGames} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={elevenGames} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 
@@ -85,7 +91,7 @@ describe('OwnedGamesTable', () => {
       }
     }))
 
-    const tree = renderer.create(<OwnedGamesTable games={twelveGames} />).toJSON()
+    const tree = renderWithColorMode(<OwnedGamesTable games={twelveGames} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
+++ b/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Theme Configuration a snapshot of the configuration matches the snapshot 1`] = `
 {
@@ -175,6 +175,12 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
         "panel-divider": [Function],
         "panel-highlight": [Function],
         "primary": "#1E90FF",
+        "tableBackground": "rgba(1, 1, 1, 0.30)",
+        "tableBorder": "rgba(255, 255, 255, 0.1)",
+        "tableHeaderBackground": "rgba(30, 37, 48, 0.8)",
+        "tableRowAlternateBackground": "rgba(30, 37, 48, 0.4)",
+        "tableRowBackground": "rgba(1, 1, 1, 0.15)",
+        "tableText": "#fff",
         "text": "#fff",
         "textMuted": "#d8d8d8",
       },
@@ -185,6 +191,11 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
     "primary": "#422EA3",
     "secondary": "#711E9B",
     "secondaryGradient": "linear-gradient(45deg, #4527a0 0%, #711e9b 100%)",
+    "tableBackground": "light",
+    "tableBorder": "muted",
+    "tableHeaderBackground": "#f4f4f9",
+    "tableRowAlternateBackground": "#fafafa",
+    "tableRowBackground": "transparent",
     "tableText": "#111",
     "text": "#111",
     "textMuted": "#333",
@@ -617,7 +628,7 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
       "minHeight": "100vh",
     },
     "table": {
-      "backgroundColor": "light",
+      "backgroundColor": "rgba(255, 255, 255, 0.35)",
       "borderCollapse": "collapse",
       "borderRadius": "10px",
       "borderSpacing": 0,
@@ -625,12 +636,15 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
       "color": "tableText",
       "marginBottom": "1.5rem",
       "overflow": "hidden",
+      "tbody tr:nth-of-type(even)": {
+        "backgroundColor": "tableRowBackground",
+      },
       "tbody tr:nth-of-type(odd)": {
-        "backgroundColor": "#fafafa",
+        "backgroundColor": "tableRowAlternateBackground",
       },
       "th": {
-        "backgroundColor": "#f4f4f9",
-        "borderColor": "muted",
+        "backgroundColor": "tableHeaderBackground",
+        "borderColor": "tableBorder",
         "borderTop": "2px solid",
         "fontWeight": "bold",
         "letterSpacing": "0.05em",
@@ -638,7 +652,42 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
       },
       "th, td": {
         "borderBottom": "1px solid",
-        "borderColor": "muted",
+        "borderColor": "tableBorder",
+        "fontSize": "1.125em",
+        "padding": "12px 15px",
+        "textAlign": "left",
+      },
+      "width": "100%",
+    },
+    "tableDark": {
+      "WebkitBackdropFilter": "blur(10px)",
+      "backdropFilter": "blur(10px)",
+      "backgroundColor": "rgba(30, 30, 47, 0.35)",
+      "border": "1px solid rgba(255, 255, 255, 0.15)",
+      "borderCollapse": "collapse",
+      "borderRadius": "10px",
+      "borderSpacing": 0,
+      "boxShadow": "0 0 20px rgba(0, 0, 0, 0.3)",
+      "color": "tableText",
+      "marginBottom": "1.5rem",
+      "overflow": "hidden",
+      "tbody tr:nth-of-type(even)": {
+        "backgroundColor": "tableRowBackground",
+      },
+      "tbody tr:nth-of-type(odd)": {
+        "backgroundColor": "tableRowAlternateBackground",
+      },
+      "th": {
+        "backgroundColor": "tableHeaderBackground",
+        "borderColor": "tableBorder",
+        "borderTop": "2px solid",
+        "fontWeight": "bold",
+        "letterSpacing": "0.05em",
+        "textTransform": "uppercase",
+      },
+      "th, td": {
+        "borderBottom": "1px solid",
+        "borderColor": "tableBorder",
         "fontSize": "1.125em",
         "padding": "12px 15px",
         "textAlign": "left",

--- a/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
+++ b/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
@@ -644,15 +644,11 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
       },
       "th": {
         "backgroundColor": "tableHeaderBackground",
-        "borderColor": "tableBorder",
-        "borderTop": "2px solid",
         "fontWeight": "bold",
         "letterSpacing": "0.05em",
         "textTransform": "uppercase",
       },
       "th, td": {
-        "borderBottom": "1px solid",
-        "borderColor": "tableBorder",
         "fontSize": "1.125em",
         "padding": "12px 15px",
         "textAlign": "left",
@@ -679,15 +675,11 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
       },
       "th": {
         "backgroundColor": "tableHeaderBackground",
-        "borderColor": "tableBorder",
-        "borderTop": "2px solid",
         "fontWeight": "bold",
         "letterSpacing": "0.05em",
         "textTransform": "uppercase",
       },
       "th, td": {
-        "borderBottom": "1px solid",
-        "borderColor": "tableBorder",
         "fontSize": "1.125em",
         "padding": "12px 15px",
         "textAlign": "left",

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -201,13 +201,24 @@ export default merge(tailwind, {
         'panel-highlight': theme => theme.colors.gray[8],
         primary: '#1E90FF',
         text: '#fff',
-        textMuted: '#d8d8d8'
+        textMuted: '#d8d8d8',
+        tableText: '#fff',
+        tableBackground: 'rgba(1, 1, 1, 0.30)',
+        tableHeaderBackground: 'rgba(30, 37, 48, 0.8)',
+        tableRowBackground: 'rgba(1, 1, 1, 0.15)',
+        tableRowAlternateBackground: 'rgba(30, 37, 48, 0.4)',
+        tableBorder: 'rgba(255, 255, 255, 0.1)'
       }
     },
     primary: '#422EA3',
     secondary: '#711E9B',
     secondaryGradient: 'linear-gradient(45deg, #4527a0 0%, #711e9b 100%)',
     tableText: '#111',
+    tableBackground: 'light',
+    tableHeaderBackground: '#f4f4f9',
+    tableRowBackground: 'transparent',
+    tableRowAlternateBackground: '#fafafa',
+    tableBorder: 'muted',
     text: '#111',
     textMuted: '#333'
   },
@@ -291,7 +302,7 @@ export default merge(tailwind, {
     },
 
     table: {
-      backgroundColor: 'light',
+      backgroundColor: 'rgba(255, 255, 255, 0.35)',
       color: 'tableText',
       width: '100%',
       borderCollapse: 'collapse',
@@ -303,20 +314,49 @@ export default merge(tailwind, {
       'th, td': {
         fontSize: '1.125em',
         textAlign: 'left',
-        padding: '12px 15px',
-        borderBottom: '1px solid',
-        borderColor: 'muted'
+        padding: '12px 15px'
       },
       th: {
-        backgroundColor: '#f4f4f9',
+        backgroundColor: 'tableHeaderBackground',
         fontWeight: 'bold',
         textTransform: 'uppercase',
-        letterSpacing: '0.05em',
-        borderTop: '2px solid',
-        borderColor: 'muted'
+        letterSpacing: '0.05em'
       },
       'tbody tr:nth-of-type(odd)': {
-        backgroundColor: '#fafafa'
+        backgroundColor: 'tableRowAlternateBackground'
+      },
+      'tbody tr:nth-of-type(even)': {
+        backgroundColor: 'tableRowBackground'
+      }
+    },
+
+    tableDark: {
+      ...glassmorhismPanel,
+      backgroundColor: 'rgba(30, 30, 47, 0.35)',
+      color: 'tableText',
+      width: '100%',
+      borderCollapse: 'collapse',
+      borderSpacing: 0,
+      marginBottom: '1.5rem',
+      overflow: 'hidden',
+      borderRadius: '10px',
+      boxShadow: '0 0 20px rgba(0, 0, 0, 0.3)',
+      'th, td': {
+        fontSize: '1.125em',
+        textAlign: 'left',
+        padding: '12px 15px'
+      },
+      th: {
+        backgroundColor: 'tableHeaderBackground',
+        fontWeight: 'bold',
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em'
+      },
+      'tbody tr:nth-of-type(odd)': {
+        backgroundColor: 'tableRowAlternateBackground'
+      },
+      'tbody tr:nth-of-type(even)': {
+        backgroundColor: 'tableRowBackground'
       }
     },
 

--- a/theme/wrapRootElement.js
+++ b/theme/wrapRootElement.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { Global, CacheProvider } from '@emotion/react'
 import createCache from '@emotion/cache'
-import { jsx } from 'theme-ui'
+import { jsx, useColorMode } from 'theme-ui'
 import { MDXProvider } from '@mdx-js/react'
 import { Provider as ReduxProvider } from 'react-redux'
 import { Themed } from '@theme-ui/mdx'
@@ -16,12 +16,20 @@ import YouTube from './src/shortcodes/youtube'
 // Create an Emotion cache
 const cache = createCache({ key: 'css', prepend: true })
 
+// Table component that adapts to color mode
+const Table = props => {
+  const [colorMode] = useColorMode()
+  const tableVariant = colorMode === 'dark' ? 'styles.tableDark' : 'styles.table'
+
+  return <Themed.table {...props} sx={{ variant: tableVariant }} />
+}
+
 // Define MDX components
 const components = {
   Emoji,
   pre: ({ children }) => <>{children}</>,
   YouTube,
-  Table: props => <Themed.table {...props} sx={{ variant: 'styles.table' }} />
+  Table
 }
 
 const WrapRootElement = ({ element }) => (


### PR DESCRIPTION
This PR styles <table /> elements to recognize and use the color mode.

| Light Mode | Dark Mode |
|------------|-----------|
|      <img width="1729" alt="light-mode-table" src="https://github.com/user-attachments/assets/1a38caa2-bd55-43fe-8a1f-bc9a68712078" />      |      <img width="1729" alt="dark-mode-table" src="https://github.com/user-attachments/assets/11874426-f241-4e4d-85bb-20d798149746" />     |

## AI summary

This pull request updates the snapshot tests for the `OwnedGamesTable` component in `theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap`. The changes primarily involve updating CSS class names to reflect recent styling adjustments.

Styling updates:

* Updated the table's class name from `css-zezy6m` to `css-1intvy2` for both test cases. [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL5-R5) [[2]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL342-R342)
* Changed the CSS class for game container elements from `css-b0fne7` to `css-uoday8` across multiple rows in both test cases. [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL24-R32) [[2]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL50-R58) [[3]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL80-R88) [[4]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL106-R114) [[5]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL136-R144) [[6]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL162-R170) [[7]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL192-R200) [[8]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL218-R226) [[9]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL248-R256) [[10]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL274-R282) [[11]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL361-R369) [[12]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL387-R395) [[13]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL417-R425) [[14]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL443-R451) [[15]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL473-R481) [[16]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL499-R507) [[17]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL529-R537) [[18]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL555-R563)
* Updated the CSS class for game links from `css-1mawu4u` to `css-rferrc` across all rows in both test cases. [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL24-R32) [[2]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL50-R58) [[3]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL80-R88) [[4]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL106-R114) [[5]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL136-R144) [[6]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL162-R170) [[7]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL192-R200) [[8]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL218-R226) [[9]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL248-R256) [[10]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL274-R282) [[11]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL361-R369) [[12]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL387-R395) [[13]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL417-R425) [[14]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL443-R451) [[15]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL473-R481) [[16]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL499-R507) [[17]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL529-R537) [[18]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL555-R563)
* Adjusted the CSS class for the separator span from `css-1nxn0wh` to `css-1ru781j` across multiple rows in both test cases. [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL71-R71) [[2]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL127-R127) [[3]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL183-R183) [[4]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL239-R239) [[5]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL295-R295) [[6]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL408-R408) [[7]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL464-R464) [[8]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL520-R520) [[9]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL576-R576)
* Updated the CSS class for the "other games" link from `css-1vh3e7c` to `css-1lwlkan`.