### PR TITLE
feat: lazy load all <img/> elements

### DIFF
--- a/theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snap
+++ b/theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TrackPreview matches the snapshot 1`] = `
 <a
@@ -10,6 +10,7 @@ exports[`TrackPreview matches the snapshot 1`] = `
     alt="album cover"
     className="css-o32fug"
     crossOrigin="anonymous"
+    loading="lazy"
     src="https://placehold.it/400/400"
   />
 </a>

--- a/theme/src/components/widgets/spotify/track-preview.js
+++ b/theme/src/components/widgets/spotify/track-preview.js
@@ -12,6 +12,7 @@ const TrackPreview = ({ link, name, thumbnailURL }) => (
   >
     <img
       alt='album cover'
+      loading='lazy'
       crossOrigin='anonymous'
       src={thumbnailURL}
       sx={{

--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -26,6 +26,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 1 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-1-icon.jpg"
           />
           <a
@@ -52,6 +53,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 2 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-2-icon.jpg"
           />
           <a
@@ -82,6 +84,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 3 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-3-icon.jpg"
           />
           <a
@@ -108,6 +111,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 4 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-4-icon.jpg"
           />
           <a
@@ -138,6 +142,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 5 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-5-icon.jpg"
           />
           <a
@@ -164,6 +169,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 6 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-6-icon.jpg"
           />
           <a
@@ -194,6 +200,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 7 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-7-icon.jpg"
           />
           <a
@@ -220,6 +227,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 8 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-8-icon.jpg"
           />
           <a
@@ -250,6 +258,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 9 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-9-icon.jpg"
           />
           <a
@@ -276,6 +285,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
           <img
             alt="Game 10 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-10-icon.jpg"
           />
           <a
@@ -363,6 +373,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 1 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-1-icon.jpg"
           />
           <a
@@ -389,6 +400,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 2 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-2-icon.jpg"
           />
           <a
@@ -419,6 +431,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 3 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-3-icon.jpg"
           />
           <a
@@ -445,6 +458,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 4 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-4-icon.jpg"
           />
           <a
@@ -475,6 +489,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 5 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-5-icon.jpg"
           />
           <a
@@ -501,6 +516,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 6 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-6-icon.jpg"
           />
           <a
@@ -531,6 +547,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 7 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-7-icon.jpg"
           />
           <a
@@ -557,6 +574,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 8 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-8-icon.jpg"
           />
           <a
@@ -587,6 +605,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 9 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-9-icon.jpg"
           />
           <a
@@ -613,6 +632,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
           <img
             alt="Game 10 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-10-icon.jpg"
           />
           <a
@@ -701,6 +721,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 1 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-1-icon.jpg"
           />
           <a
@@ -727,6 +748,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 2 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-2-icon.jpg"
           />
           <a
@@ -757,6 +779,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 3 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-3-icon.jpg"
           />
           <a
@@ -783,6 +806,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 4 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-4-icon.jpg"
           />
           <a
@@ -813,6 +837,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 5 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-5-icon.jpg"
           />
           <a
@@ -839,6 +864,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 6 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-6-icon.jpg"
           />
           <a
@@ -869,6 +895,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 7 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-7-icon.jpg"
           />
           <a
@@ -895,6 +922,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 8 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-8-icon.jpg"
           />
           <a
@@ -925,6 +953,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 9 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-9-icon.jpg"
           />
           <a
@@ -951,6 +980,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
           <img
             alt="Game 10 icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/game-10-icon.jpg"
           />
           <a
@@ -1039,6 +1069,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
           <img
             alt="Cities: Skylines icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/cities-icon.jpg"
           />
           <a
@@ -1065,6 +1096,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
           <img
             alt="ARK: Survival Evolved icon"
             className="css-sfnjuk"
+            loading="lazy"
             src="https://example.com/ark-icon.jpg"
           />
           <a

--- a/theme/src/components/widgets/steam/owned-games-table.js
+++ b/theme/src/components/widgets/steam/owned-games-table.js
@@ -39,6 +39,7 @@ const OwnedGamesTable = ({ games = [] }) => {
             <td>
               <div sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
                 <img
+                  loading='lazy'
                   src={game.images?.icon}
                   alt={`${game.displayName} icon`}
                   sx={{

--- a/www.chrisvogt.me/content/blog/2024-06-18-evolution-of-this-blog.mdx
+++ b/www.chrisvogt.me/content/blog/2024-06-18-evolution-of-this-blog.mdx
@@ -56,6 +56,7 @@ So I rewrote my personal website to better match the tech I used at work. I want
 To handle API rate limits and server-side calls, I created a [Personal Stats API](https://github.com/chrisvogt/stats) using CakePHP, tracking time spent coding and visualizing the data on my stats subdomain. For a while it was also the backend behind my home page widgets.
 
 <img
+  loading='lazy'
   className='solid-background'
   alt='Data flow diagram for my personal website v1.x.'
   src='https://res.cloudinary.com/chrisvogt/image/upload/v1718781949/posts/2019-data-diagram.webp'
@@ -76,6 +77,7 @@ This experience led me to rewrite my front end using GatsbyJS + React with the i
 After replacing the front end, I replaced my Personal Stats API with [metrics.chrisvogt.me](https://github.com/chrisvogt/metrics), an API and collection of Node.js scripts deployed to Google Cloud Platform with Firebase that run on scheduled jobs and update a Firestore database. The current version of my website still uses these technologies.
 
 <img
+  loading='lazy'
   className='solid-background'
   alt="My website's architecture as of June 2024."
   src='https://res.cloudinary.com/chrisvogt/image/upload/v1718782557/posts/2024-data-diagram.webp'

--- a/www.chrisvogt.me/content/music/2024-10-14-ebb-tide.mdx
+++ b/www.chrisvogt.me/content/music/2024-10-14-ebb-tide.mdx
@@ -26,6 +26,7 @@ This recording was done in one take, aiming to capture the essence of the song i
 Thanks for taking the time to listen!
 
 <img
+  loading='lazy'
   src='https://res.cloudinary.com/chrisvogt/image/upload/w_1000,h_750,ar_1:1,c_fill,g_auto/v1728942076/chrisvogt-me/photo/FullSizeRender.jpg'
   width='100%'
   height='auto'


### PR DESCRIPTION
This PR updates all images to be lazy loaded using the [loading='lazy'](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img#loading) attribute.

## AI summary

This pull request introduces optimizations to improve performance by adding lazy loading to images across multiple components (`TrackPreview` and `OwnedGamesTable`) and updates snapshot testing documentation for clarity. The most important changes include enabling lazy loading for images in both the Spotify and Steam widgets and updating snapshot files to reflect these changes.

### Performance optimizations:

* **Lazy loading in `TrackPreview` component**:
  - Added the `loading='lazy'` attribute to the `<img>` tag in the `TrackPreview` component to improve performance by deferring image loading until necessary. (`theme/src/components/widgets/spotify/track-preview.js`, [theme/src/components/widgets/spotify/track-preview.jsR15](diffhunk://#diff-0fa83e48aae173b08a61a353d8f41090b396eb1cb5420604237816ba08030efaR15))
  - Updated the corresponding snapshot file to include the `loading="lazy"` attribute. (`theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snap`, [theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snapR13](diffhunk://#diff-185b2edcc7bcf012fe98b648d6ac14494c2e429552d9721b55a81f2171212433R13))

* **Lazy loading in `OwnedGamesTable` component**:
  - Added the `loading='lazy'` attribute to the `<img>` tag in the `OwnedGamesTable` component to optimize image loading for game icons. (`theme/src/components/widgets/steam/owned-games-table.js`, [theme/src/components/widgets/steam/owned-games-table.jsR42](diffhunk://#diff-3abde98fe1344b271a0f9e8d4da14e9472195fee3d73e35d44252205266e1bfbR42))
  - Updated multiple snapshot files to include the `loading="lazy"` attribute for game icons across various test cases. (`theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap`, [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eR29) [[2]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eR376) [[3]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eR1072) and others)

### Documentation updates:

* **Snapshot testing documentation**:
  - Updated the snapshot testing documentation link in the `TrackPreview` snapshot file for better clarity and to point to the official Jest documentation. (`theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snap`, [theme/src/components/widgets/spotify/__snapshots__/track-preview.spec.js.snapL1-R1](diffhunk://#diff-185b2edcc7bcf012fe98b648d6ac14494c2e429552d9721b55a81f2171212433L1-R1))