### PR TITLE
content: clean up the latest blog post text

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-01-07-my-piano-repertoire.mdx
+++ b/www.chrisvogt.me/content/blog/2025-01-07-my-piano-repertoire.mdx
@@ -20,8 +20,14 @@ keywords:
   ]
 ---
 
-For years, I kept track of the songs I wanted to learn and practice on piano in a simple text file. In March 2020, I decided to better organize my repertoire by moving the list to a Google Sheet. This made it easier to track my progress and share updates with friends who were interested in hearing me play or record my performances.
+For a long time, I kept a running list of songs I wanted to learn on piano in a plain text file. Nothing fancy—just a quick way to jot things down as they came to me. Then in early 2020, I moved everything into a Google Sheet so I could track my progress a bit more thoughtfully. It also made it easier to share with friends who were curious about what I was working on or wanted to hear a recording.
 
-Fast forward to 2025, and I’ve taken the next step: publishing the list online to make it even more accessible. I built a straightforward Next.js single-page app to display the songs, along with notes on my performance quality and transpositions needed to play them in their original keys. The app also includes links to sheet music for each piece.
+Now in 2025, I’ve taken it a step further and put the whole thing online. I built a simple single-page app with Next.js that displays my full repertoire, including notes about how well I feel I can play each piece and whether I had to transpose it to get it closer to the original key. I also included links to sheet music when available, in case you're looking to try any of the songs yourself.
 
-You can explore it here: [repertoire.chrisvogt.me](https://repertoire.chrisvogt.me). If you're curious about the code behind it, check out the repository on GitHub: [github.com/chrisvogt/repertoire.chrisvogt.me](https://github.com/chrisvogt/repertoire.chrisvogt.me).
+<img
+  loading='lazy'
+  alt='A screenshot of repertoire.chrisvogt.me'
+  src='https://res.cloudinary.com/chrisvogt/image/upload/v1750377146/chrisvogt-me/photo/piano-screenshot.webp'
+/>
+
+Explore the full list in person here: [repertoire.chrisvogt.me](https://repertoire.chrisvogt.me). And if you're curious about how it's built, here's [the code on GitHub](https://github.com/chrisvogt/repertoire.chrisvogt.me).

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
This PR does a pass at cleaning up the text on my latest blog post. It also adds a screenshot of the app described in that post.

## AI summary

This pull request includes updates to the blog post about the piano repertoire and a version bump in the `package.json` file. The blog post revisions improve readability and enhance user engagement, while the version update reflects these changes.

### Blog post updates:
* [`www.chrisvogt.me/content/blog/2025-01-07-my-piano-repertoire.mdx`](diffhunk://#diff-07ff2c8353f84b24100973541f673a30b010b2bb51b5d8d081c61c3902dffc3eL23-R33): Revised the blog post to improve clarity and engagement, including rephrased sentences for better readability, added a screenshot of the repertoire app, and updated links to make them more user-friendly.

### Version update:
* [`www.chrisvogt.me/package.json`](diffhunk://#diff-345f7dcb2c5893ce5467041532f4bf4892e2f6b8c97661561f45faba61d7afe9L4-R4): Bumped the version number from `1.5.1` to `1.5.2` to reflect the blog post updates.