### PR TITLE
feat: add Mastodon to my social profiles list

### DIFF
--- a/theme/src/components/footer/profiles.js
+++ b/theme/src/components/footer/profiles.js
@@ -10,6 +10,7 @@ import {
   faGithub,
   faInstagram,
   faLinkedin,
+  faMastodon,
   faStackOverflow,
   faXTwitter
 } from '@fortawesome/free-brands-svg-icons'
@@ -29,6 +30,7 @@ const icons = {
   faGithub,
   faInstagram,
   faLinkedin,
+  faMastodon,
   faStackOverflow,
   faXTwitter
 }

--- a/theme/src/data/social-profiles.json
+++ b/theme/src/data/social-profiles.json
@@ -44,6 +44,17 @@
     }
   },
   {
+    "href": "https://hachyderm.io/@chrisvogt",
+    "slug": "mastodon",
+    "displayName": "Mastodon",
+    "icon": {
+      "class": "fab fa-x-mastodon",
+      "name": "mastodon",
+      "reactIcon": "faMastodon",
+      "set": "fab"
+    }
+  },
+  {
     "href": "https://twitter.com/c1v0",
     "slug": "twitter",
     "displayName": "Twitter",

--- a/www.chrisvogt.me/gatsby-config.js
+++ b/www.chrisvogt.me/gatsby-config.js
@@ -46,6 +46,10 @@ module.exports = {
         username: 'c1v0',
         widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/instagram'
       },
+      mastodon: {
+        username: 'chrisvogt',
+        url: 'https://hachyderm.io/@chrisvogt'
+      },
       spotify: {
         widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/spotify'
       },

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
This PR adds Mastodon to my social profiles. These profiles also need to be made more customizable, and so I've opened #340 to address that.

## AI summary

This pull request adds Mastodon as a supported social profile across the website's footer, configuration, and data files. The changes ensure Mastodon is integrated alongside existing social profiles such as Twitter and Instagram.

### Mastodon Integration:

* [`theme/src/components/footer/profiles.js`](diffhunk://#diff-d4d88521575749f15de1895de85074cd14f66229d4622fe889175533e0a8b1d1R13): Added `faMastodon` to the list of imported icons and the `icons` object to display the Mastodon icon in the footer. [[1]](diffhunk://#diff-d4d88521575749f15de1895de85074cd14f66229d4622fe889175533e0a8b1d1R13) [[2]](diffhunk://#diff-d4d88521575749f15de1895de85074cd14f66229d4622fe889175533e0a8b1d1R33)
* [`theme/src/data/social-profiles.json`](diffhunk://#diff-902a3914eb9d10670b88041bb53a44b5a6384b898e51a538432f087f63f82215R46-R56): Added Mastodon profile details, including the URL, display name, and icon configuration.
* [`www.chrisvogt.me/gatsby-config.js`](diffhunk://#diff-bd0681d8b7b489137cb1cd47b7e7174c97a72f2b5e0cacdd85a8b530e9dc5ae9R49-R52): Added Mastodon configuration with username and URL for integration into the website.

### Version Update:

* [`www.chrisvogt.me/package.json`](diffhunk://#diff-345f7dcb2c5893ce5467041532f4bf4892e2f6b8c97661561f45faba61d7afe9L4-R4): Incremented the project version from `1.5.3` to `1.5.4` to reflect the changes.