### PR TITLE
feat: replace Google web font with built-in fonts

### DIFF
--- a/theme/gatsby-config.js
+++ b/theme/gatsby-config.js
@@ -75,14 +75,6 @@ module.exports = () => ({
         name: 'content'
       }
     },
-    {
-      resolve: 'gatsby-plugin-google-fonts',
-      options: {
-        fonts: ['Crimson Text:400,400i,600'],
-        display: 'swap',
-        preconnect: true
-      }
-    },
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',
     'gatsby-plugin-emotion',

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.44.2",
+  "version": "0.44.3",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",
@@ -78,7 +78,6 @@
     "gatsby": "^5.14.3",
     "gatsby-plugin-emotion": "^8.14.0",
     "gatsby-plugin-feed": "^5.13.1",
-    "gatsby-plugin-google-fonts": "^1.0.1",
     "gatsby-plugin-manifest": "^5.13.1",
     "gatsby-plugin-mdx": "^5.14.1",
     "gatsby-plugin-sharp": "^5.13.1",

--- a/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
+++ b/theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap
@@ -232,11 +232,11 @@ exports[`Theme Configuration a snapshot of the configuration matches the snapsho
     "thin": 200,
   },
   "fonts": {
-    "body": "Crimson Text, Georgia, Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+    "body": "Iowan Old Style, Apple Garamond, Georgia, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
     "heading": "-apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif",
     "monospace": "Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace",
     "sans": "-apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif",
-    "serif": "Crimson Text, Georgia, Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
+    "serif": "Iowan Old Style, Apple Garamond, Georgia, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
   },
   "global": {
     "@keyframes wobble": {

--- a/theme/src/gatsby-plugin-theme-ui/theme.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.js
@@ -4,7 +4,7 @@ import { merge } from 'theme-ui'
 const fonts = {
   sans: '-apple-system, BlinkMacSystemFont, avenir next, avenir, helvetica neue, helvetica, Ubuntu, roboto, noto, segoe ui, arial, sans-serif',
   serif:
-    'Crimson Text, Georgia, Iowan Old Style, Apple Garamond, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
+    'Iowan Old Style, Apple Garamond, Georgia, Baskerville, Times New Roman, Droid Serif, Times, Source Serif Pro, serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol',
   mono: 'Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace'
 }
 

--- a/theme/src/gatsby-plugin-theme-ui/theme.spec.js
+++ b/theme/src/gatsby-plugin-theme-ui/theme.spec.js
@@ -32,7 +32,7 @@ describe('Theme Configuration', () => {
     })
 
     it('defines serif fonts correctly', () => {
-      expect(theme.fonts.serif).toContain('Crimson Text')
+      expect(theme.fonts.serif).toContain('Iowan Old Style')
     })
 
     it('defines monospace fonts correctly', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10672,13 +10672,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-plugin-google-fonts@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "gatsby-plugin-google-fonts@npm:1.0.1"
-  checksum: 10c0/cb3186eaa792cb9b2af4a1d7a7a1664dd61a9865a2b810f73afac5b95d3562e0b3068a627528cb108b02f851bf403e2fe921792a868e5abbc8516d659854ed7c
-  languageName: node
-  linkType: hard
-
 "gatsby-plugin-manifest@npm:^5.13.1":
   version: 5.14.0
   resolution: "gatsby-plugin-manifest@npm:5.14.0"
@@ -11043,7 +11036,6 @@ __metadata:
     gatsby: "npm:^5.14.3"
     gatsby-plugin-emotion: "npm:^8.14.0"
     gatsby-plugin-feed: "npm:^5.13.1"
-    gatsby-plugin-google-fonts: "npm:^1.0.1"
     gatsby-plugin-manifest: "npm:^5.13.1"
     gatsby-plugin-mdx: "npm:^5.14.1"
     gatsby-plugin-sharp: "npm:^5.13.1"


### PR DESCRIPTION
This PR replaces [Crimson Text](https://fonts.google.com/specimen/Crimson+Text), the Google Font, with the built-in serif fonts. This may be temporary — until I figure out how to add custom fonts back in a performant way.

<img width="1729" alt="Screenshot 2025-06-19 at 9 05 03 PM" src="https://github.com/user-attachments/assets/eccdd940-2913-4877-989a-81b44b7db9f3" />

## AI summary

This pull request removes the use of the `gatsby-plugin-google-fonts` plugin and updates the font configuration to exclude the `Crimson Text` font across the theme. The changes ensure consistency in font definitions and simplify the project's dependencies.

### Removal of `gatsby-plugin-google-fonts`:

* [`theme/gatsby-config.js`](diffhunk://#diff-be6fcca2450e9a91f8d73de644212cc2cf6723fbab853dd18f664dbb3a55fa11L78-L85): Removed the `gatsby-plugin-google-fonts` plugin configuration.
* [`theme/package.json`](diffhunk://#diff-864251b807b1925eadafb797a61b4fb855065215fc4e7129a00ec23a2dd4ed72L81): Removed the `gatsby-plugin-google-fonts` dependency.

### Font configuration updates:

* [`theme/src/gatsby-plugin-theme-ui/theme.js`](diffhunk://#diff-3fd46ce57265aea3fe70819b8934d775c4b005fa662ac1c4ced62d45fa7e49fbL7-R7): Updated the `serif` font configuration to remove `Crimson Text` and prioritize `Iowan Old Style`.
* [`theme/src/gatsby-plugin-theme-ui/__snapshots__/theme.spec.js.snap`](diffhunk://#diff-80f1f6ce5ea03267ff29273450450667528ff163b7d6ba9b1bd7a730a5f26e16L235-R239): Updated snapshot tests to reflect the new font configuration.
* [`theme/src/gatsby-plugin-theme-ui/theme.spec.js`](diffhunk://#diff-ad3d3d456468feaf66ea9169972ffa5b2a40e80f1c5053adf15cba7ff20fcaafL35-R35): Updated unit tests to validate the removal of `Crimson Text` and inclusion of `Iowan Old Style`.

### Version update:

* [`theme/package.json`](diffhunk://#diff-864251b807b1925eadafb797a61b4fb855065215fc4e7129a00ec23a2dd4ed72L4-R4): Incremented the package version from `0.44.2` to `0.44.3`.