### PR TITLE
fix: recently-played Steam games should show minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.44.4
+
+- Updates Steam widget "Recently-Played Games" to reflect MINUTES for games played.
+
 ## 0.44.0
 
 - Updates themed <table/> elements to have a light and dark mode.

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.44.3",
+  "version": "0.44.4",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -117,4 +117,4 @@ exports[`SteamWidget renders loading state 1`] = `
 </div>
 `;
 
-exports[`TimeSpent renders humanized time correctly 1`] = `"0 hours"`;
+exports[`TimeSpent renders humanized time correctly 1`] = `"5 minutes"`;

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -22,7 +22,7 @@ import { getSteamWidgetDataSource } from '../../../selectors/metadata'
 import useSiteMetadata from '../../../hooks/use-site-metadata'
 
 export const TimeSpent = ({ timeInMs }) => (
-  <Fragment>{humanizeDuration(timeInMs, { units: ['h'], round: true })}</Fragment>
+  <Fragment>{humanizeDuration(timeInMs, { units: ['h', 'm'], round: true })}</Fragment>
 )
 
 const EMPTY_ARRAY = []


### PR DESCRIPTION
This PR updates the Recently-Played Games section of the Steam widget to render gameplay down to the MINUTE instead of the HOUR.

| Before | After |
|--------|-------|
|     <img width="1729" alt="before-gameplay" src="https://github.com/user-attachments/assets/1408a85a-6317-4d4b-ab66-392df1a38fe4" />   |   <img width="1729" alt="after-gameplay" src="https://github.com/user-attachments/assets/fc453696-7860-4b3d-aaa9-e7de7fef6269" />    |