### PR TITLE
fix: teacher salary banner image headline

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-06-22-teacher-salary-info.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-22-teacher-salary-info.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Comparing Teacher Salaries Across the U.S.'
 slug: teacher-salary-info
-banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1750627218/chrisvogt-me/thumbnails/teacher-salary-banner.webp
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1750657869/chrisvogt-me/thumbnails/teacher-salary-info-banner.webp
 category: personal
 date: '2025-06-22T14:00:00.000Z'
 description: >

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
The banner artwork I'm using for the teachersalary.info post, published with #345, has an incorrect headline. This PR updates that artwork.