### PR TITLE
fix: oversized images on latest blog post — optimizes them

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-06-18-virgin-southern-caribbean/photos.js
+++ b/www.chrisvogt.me/content/blog/2025-06-18-virgin-southern-caribbean/photos.js
@@ -1,18 +1,18 @@
 export const flightToSanJuan = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231637/chrisvogt-me/galleries/2025-vsc/20250419-IMG_3558-2.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250419-IMG_3558-2.jpg',
     title: 'Nick watching baggage being loaded onto the plane while we wait to depart from Denver',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231636/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2625.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2625.jpg',
     title: 'Above the clouds',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231644/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2643.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2643.jpg',
     title: 'Landing at SJU — San Juan, Puerto Rico',
     width: 3,
     height: 4
@@ -21,25 +21,25 @@ export const flightToSanJuan = [
 
 export const exploringOldSanJuanBefore = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231638/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2680.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2680.jpg',
     title: 'Old San Juan from Mar y Rosa',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231670/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2669.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231670/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2669.jpg',
     title: 'Another shot of Old San Juan from Mar y Rosa',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231682/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2666.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2666.jpg',
     title: 'A cat in front of the ¡Boricua! sign alng the waterfront in Old San Juan',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231649/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2655.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231649/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2655.jpg',
     title: 'Mofongo at Hotel Rumbao',
     width: 3,
     height: 4
@@ -48,31 +48,31 @@ export const exploringOldSanJuanBefore = [
 
 export const architectureInSanJuan = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231651/chrisvogt-me/galleries/2025-vsc/20250329-CJV09177.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231651/chrisvogt-me/galleries/2025-vsc/20250329-CJV09177.jpg',
     title: 'Looking out over the water from Bastión de San Agustín in Old San Juan',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-CJV09169.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-CJV09169.jpg',
     title: 'A lookout entrance at Bastión de San Agustín in Old San Juan',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231677/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2723.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231677/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2723.jpg',
     title: 'Casa Borinquen on Calle de San Sebastián in Old San Juan',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2718.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2718.jpg',
     title: 'Iglesia San José in Old San Juan',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231646/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2662.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231646/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2662.jpg',
     title: 'A door with an awning that says "Coqui Forest" in Old San Juan',
     width: 3,
     height: 4
@@ -81,25 +81,25 @@ export const architectureInSanJuan = [
 
 export const streetPhotographyInSanJuan = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231694/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2745.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231694/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2745.jpg',
     title: 'Looking down C. de San Sebastián from El CAFETÍN in Old San Juan',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231674/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2746.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231674/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2746.jpg',
     title: 'People in the street outside of El CAFETÍN',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231639/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2741.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231639/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2741.jpg',
     title: 'Nick at El CAFETÍN, take 1',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231654/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2742.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231654/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2742.jpg',
     title: 'Nick at El CAFETÍN, take 2',
     width: 4,
     height: 3
@@ -108,25 +108,25 @@ export const streetPhotographyInSanJuan = [
 
 export const friendsArrivedInSanJuan = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231679/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2752.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231679/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2752.jpg',
     title: 'Plaza Colón in Viejo San Juan',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231647/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2756.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2756.jpg',
     title: 'Matt sitting on a bench in Viejo San Juan',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231673/chrisvogt-me/galleries/2025-vsc/20250331-IMG_4386.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250331-IMG_4386.jpg',
     title: 'The group eating at Puerto Criollo in Old San Juan, Puerto Rico',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231662/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2763.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231662/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2763.jpg',
     title: 'Chicken and rice in a mushroom sauce at Puerto Criollo',
     width: 4,
     height: 3
@@ -135,19 +135,19 @@ export const friendsArrivedInSanJuan = [
 
 export const settingSail = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231667/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2796.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231667/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2796.jpg',
     title: 'Celebrity Equinox, MSC Seascape and Resiliant Lady at port in San Juan',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231652/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2799.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2799.jpg',
     title: 'Resiliant Lady at port in San Juan',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231637/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2811.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2811.jpg',
     title: 'Nick celebrating setting sail',
     width: 3,
     height: 4
@@ -156,25 +156,25 @@ export const settingSail = [
 
 export const earlyShipDays = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231645/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2861.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231645/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2861.jpg',
     title: 'The squad trying on different types of sunglasses',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231647/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2835.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2835.jpg',
     title: 'Volleyball on the ship',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231689/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2868.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231689/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2868.jpg',
     title: 'Goofy times at the carousel on the ship',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231648/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2828.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231648/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2828.jpg',
     title: 'The group walking down the stairs to the pool',
     width: 3,
     height: 4
@@ -183,13 +183,13 @@ export const earlyShipDays = [
 
 export const eatingAtGunbae = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231655/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2831.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231655/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2831.jpg',
     title: 'Eating at Gunbae, a Korean BBQ restaurant on the ship, with Krish',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231687/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2830.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231687/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2830.jpg',
     title: 'The food at Gunbae',
     width: 4,
     height: 3
@@ -198,55 +198,55 @@ export const eatingAtGunbae = [
 
 export const birdsOfCartagena = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231690/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2883.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231690/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2883.jpg',
     title: 'Birds in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231648/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2895.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231648/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2895.jpg',
     title: 'Birds in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231699/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2907.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231699/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2907.jpg',
     title: 'Indian peafowl — a peacock — in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231649/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2912.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231649/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2912.jpg',
     title: 'A tucan in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2915.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2915.jpg',
     title: 'A golden pheasant (Chrysolophus pictus)',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2918.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2918.jpg',
     title: 'A juvenile scarlet ibis (Eudocimus ruber)',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2922.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2922.jpg',
     title: 'A pair of Peruvian Thick-knees (Hesperoburhinus superciliaris)',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2924.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2924.jpg',
     title: 'White peafowl in Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2926.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2926.jpg',
     title: 'A salmon-crested cockatoo (Cacatua moluccensis)',
     width: 3,
     height: 4
@@ -255,55 +255,55 @@ export const birdsOfCartagena = [
 
 export const cartagenaStreets = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231668/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2939.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2939.jpg',
     title: 'The streets of Getsemaní, Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231676/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3007.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231676/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3007.jpg',
     title: 'Walking around exploring the streets of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231685/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2946.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2946.jpg',
     title: 'Classic, vintage cars in Getsemaní, Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231664/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2949.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231664/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2949.jpg',
     title: 'Castillo San Felipe de Barajast',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231686/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2979.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231686/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2979.jpg',
     title: "It's wine-o-click somewhere",
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231680/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2977.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231680/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2977.jpg',
     title: 'Calle de Las Sombrillas in the Getsemaní neighborhood',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231665/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2942.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231665/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2942.jpg',
     title: 'Street in Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231646/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3033.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231646/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3033.jpg',
     title: 'Street in Cartagena, Colombia at night',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231696/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3037.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231696/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3037.jpg',
     title: 'Stained glass windows in a church',
     width: 3,
     height: 4
@@ -312,25 +312,25 @@ export const cartagenaStreets = [
 
 export const cartagenaRooftops = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231637/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2994.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2994.jpg',
     title: 'Rooftop view with church',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2997.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2997.jpg',
     title: 'Rooftop view looking down',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231666/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2987.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231666/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2987.jpg',
     title: 'Another rooftop view from Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2965.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2965.jpg',
     title: 'Looking inland from Cartagena, Colombia',
     width: 4,
     height: 3
@@ -339,37 +339,37 @@ export const cartagenaRooftops = [
 
 export const cartagenaFriends = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231644/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2992.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2992.jpg',
     title: 'Nick and Roc',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231647/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2991.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2991.jpg',
     title: 'Matt',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231657/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2960.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231657/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2960.jpg',
     title: 'Happy, hungry Matt',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2962.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2962.jpg',
     title: 'Blue crab nachos 🤤',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231636/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3028.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3028.jpg',
     title: 'Chris and Nick getting seafood for dinner',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231652/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3026.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3026.jpg',
     title: 'A seafood platter in Cartagena, Colombia',
     width: 4,
     height: 3
@@ -378,25 +378,25 @@ export const cartagenaFriends = [
 
 export const curacaoFriends = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09225.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09225.jpg',
     title: 'Matt up close',
     width: 16,
     height: 9
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-CJV09220.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-CJV09220.jpg',
     title: 'Roc up close',
     width: 16,
     height: 9
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09229.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09229.jpg',
     title: 'Nick up close',
     width: 16,
     height: 9
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231659/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3130.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3130.jpg',
     title: 'The group walking across Queen Emma Bridge',
     width: 3,
     height: 4
@@ -405,31 +405,31 @@ export const curacaoFriends = [
 
 export const curacaoStreets = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231642/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3127.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231642/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3127.jpg',
     title: 'Queen Emma Bridge in Curaçao',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231654/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3138.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231654/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3138.jpg',
     title: 'Looking across Queen Emma Bridge in Curaçao',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231656/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3123.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231656/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3123.jpg',
     title: 'A variety of different types of Curaçao liqueur',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231696/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3131.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231696/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3131.jpg',
     title: 'Street murals in Curaçao',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231679/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3132.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231679/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3132.jpg',
     title: 'A Dutch newspaper stand in Curaçao',
     width: 3,
     height: 4
@@ -438,55 +438,55 @@ export const curacaoStreets = [
 
 export const scarletNightAndAtSea = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231685/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3153.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3153.jpg',
     title: 'Nick getting his face painted at Scarlet Night',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231640/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3162.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3162.jpg',
     title: 'Nick with his face painted',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231665/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3167.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231665/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3167.jpg',
     title: 'Matt on Scarlet Night',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231653/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3173.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3173.jpg',
     title: 'Chris on Scarlet Night',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231694/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3184.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231694/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3184.jpg',
     title: 'The Octopus Garden aboard Resiliant Lady',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3189.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3189.jpg',
     title: 'The group has drinks at the pool bar on Scarlet Night',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231660/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3248.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231660/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3248.jpg',
     title: 'Chris and Nick at the casino',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231653/chrisvogt-me/galleries/2025-vsc/20250409-IMG_8484.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250409-IMG_8484.jpg',
     title: 'Chris and Nick in the casino',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231644/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3274.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3274.jpg',
     title: 'Matt putting feathers in his hair',
     width: 3,
     height: 4
@@ -495,25 +495,25 @@ export const scarletNightAndAtSea = [
 
 export const antiguaFirstSpot = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231668/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3282.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3282.jpg',
     title: 'Nick looking at a lizard in Antigua',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231653/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3287.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3287.jpg',
     title: "Griswold's ameiva (Pholidoscelis griswoldi) in Antigua",
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231641/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3290.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231641/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3290.jpg',
     title: 'A catamaran docked in St. John’s, Antigua',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231682/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3292.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3292.jpg',
     title: "The Captain's Tavern in St. John's, Antigua",
     width: 3,
     height: 4
@@ -522,37 +522,37 @@ export const antiguaFirstSpot = [
 
 export const antiguaFloatingBar = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231645/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3295.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231645/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3295.jpg',
     title: 'Riding a boat to the floating bar in Dickenson Bay, Antigua',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231680/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3301.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231680/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3301.jpg',
     title: 'Looking into the floating bar',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231657/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3321.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231657/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3321.jpg',
     title: 'Kon Tiki, a floating bar',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231650/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3308.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231650/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3308.jpg',
     title: "Nick doesn't want to leave, ever",
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231644/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3350.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3350.jpg',
     title: 'Looking inland',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231636/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3359.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3359.jpg',
     title: 'Sunset at Kon Tiki, in Dickenson Bay',
     width: 4,
     height: 3
@@ -561,31 +561,31 @@ export const antiguaFloatingBar = [
 
 export const stMaarten = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231676/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3390.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231676/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3390.jpg',
     title: 'The gang in St. Maarten',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231641/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3409.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231641/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3409.jpg',
     title: 'Happy Nick on a boat in St. Maarten',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231671/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3426.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231671/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3426.jpg',
     title: 'A small boat in the port of St Maarten',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231664/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3412.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231664/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3412.jpg',
     title: 'Resiliant Lady docked in St. Maarten',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231682/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3381.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3381.jpg',
     title: 'Cocktails menu at a beach bar in St. Maarten',
     width: 3,
     height: 4
@@ -594,25 +594,25 @@ export const stMaarten = [
 
 export const finalSanJuan = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231652/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3449.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3449.jpg',
     title: 'Playa Ocean Park in San Juan, PR',
     width: 3,
     height: 4
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231642/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3522.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231642/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3522.jpg',
     title: 'Looking north from Playa Ocean Park at sunset',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231662/chrisvogt-me/galleries/2025-vsc/20250412-IMG_3446.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231662/chrisvogt-me/galleries/2025-vsc/20250412-IMG_3446.jpg',
     title: 'Dinner at Barbacoa Puerto Rico 🤤',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231688/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3451.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231688/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3451.jpg',
     title: 'The street cats of San Juan, PR',
     width: 3,
     height: 4
@@ -621,19 +621,19 @@ export const finalSanJuan = [
 
 export const friendsWeMadeInSanJuan = [
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231668/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3477.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3477.jpg',
     title: 'Chris, Tiff and Nick at Condado Beach in San Juan',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231670/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3474.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231670/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3474.jpg',
     title: 'Dancing to disco on Condado Beach while the sun sets',
     width: 4,
     height: 3
   },
   {
-    src: 'https://res.cloudinary.com/chrisvogt/image/upload/v1750231685/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3536.jpg',
+    src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3536.jpg',
     title: 'José and Nick on the patio',
     width: 4,
     height: 3

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
This PR fixes the blog post checked in with #331. The images on that page are currently much too large, resulting in a shocking Network payload when visiting the page. These were my findings.

* Uploaded takes 149,444KB of images
* Using f_auto takes that down to 44,000KB
* Adding a scale with a max height of 900px reduces that down to 18,000KB

| Before | After |
|--------|-------|
|     <img width="1685" alt="before-optimize" src="https://github.com/user-attachments/assets/78705741-4b0f-47d7-871a-f7c1d8354032" />   |    <img width="1685" alt="after-optimize" src="https://github.com/user-attachments/assets/48b107a5-2eb2-4fdc-b097-90189c5a353e" />    |

I can improve that further, but for now, this at least gets me to a less shocking size. I'm going to look into lazy loading the thumbnail artwork for the lightgallery as well.



