### PR TITLE
optimize photo gallery - init

### DIFF
--- a/www.chrisvogt.me/components/PhotoGallery.js
+++ b/www.chrisvogt.me/components/PhotoGallery.js
@@ -36,8 +36,9 @@ export const PhotoGallery = ({ photos }) => {
         download={false}
         dynamic
         dynamicEl={photos.map(photo => ({
+          alt: photo.title,
           src: photo.src,
-          thumb: photo.src,
+          thumb: photo.thumb || photo.src, // fallback to image src if thumb is not provided
           subHtml: photo.title || ''
         }))}
         speed={1000}

--- a/www.chrisvogt.me/content/blog/2025-06-18-virgin-southern-caribbean/photos.js
+++ b/www.chrisvogt.me/content/blog/2025-06-18-virgin-southern-caribbean/photos.js
@@ -1,18 +1,24 @@
 export const flightToSanJuan = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250419-IMG_3558-2.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250419-IMG_3558-2.jpg',
     title: 'Nick watching baggage being loaded onto the plane while we wait to depart from Denver',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2625.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2625.jpg',
     title: 'Above the clouds',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2643.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2643.jpg',
     title: 'Landing at SJU — San Juan, Puerto Rico',
     width: 3,
     height: 4
@@ -22,24 +28,32 @@ export const flightToSanJuan = [
 export const exploringOldSanJuanBefore = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2680.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2680.jpg',
     title: 'Old San Juan from Mar y Rosa',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231670/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2669.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231670/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2669.jpg',
     title: 'Another shot of Old San Juan from Mar y Rosa',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2666.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2666.jpg',
     title: 'A cat in front of the ¡Boricua! sign alng the waterfront in Old San Juan',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231649/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2655.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231649/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2655.jpg',
     title: 'Mofongo at Hotel Rumbao',
     width: 3,
     height: 4
@@ -49,30 +63,40 @@ export const exploringOldSanJuanBefore = [
 export const architectureInSanJuan = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231651/chrisvogt-me/galleries/2025-vsc/20250329-CJV09177.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231651/chrisvogt-me/galleries/2025-vsc/20250329-CJV09177.jpg',
     title: 'Looking out over the water from Bastión de San Agustín in Old San Juan',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-CJV09169.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-CJV09169.jpg',
     title: 'A lookout entrance at Bastión de San Agustín in Old San Juan',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231677/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2723.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231677/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2723.jpg',
     title: 'Casa Borinquen on Calle de San Sebastián in Old San Juan',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2718.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2718.jpg',
     title: 'Iglesia San José in Old San Juan',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231646/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2662.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231646/chrisvogt-me/galleries/2025-vsc/20250328-IMG_2662.jpg',
     title: 'A door with an awning that says "Coqui Forest" in Old San Juan',
     width: 3,
     height: 4
@@ -82,24 +106,32 @@ export const architectureInSanJuan = [
 export const streetPhotographyInSanJuan = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231694/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2745.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231694/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2745.jpg',
     title: 'Looking down C. de San Sebastián from El CAFETÍN in Old San Juan',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231674/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2746.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231674/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2746.jpg',
     title: 'People in the street outside of El CAFETÍN',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231639/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2741.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231639/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2741.jpg',
     title: 'Nick at El CAFETÍN, take 1',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231654/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2742.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231654/chrisvogt-me/galleries/2025-vsc/20250329-IMG_2742.jpg',
     title: 'Nick at El CAFETÍN, take 2',
     width: 4,
     height: 3
@@ -109,24 +141,32 @@ export const streetPhotographyInSanJuan = [
 export const friendsArrivedInSanJuan = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231679/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2752.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231679/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2752.jpg',
     title: 'Plaza Colón in Viejo San Juan',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2756.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2756.jpg',
     title: 'Matt sitting on a bench in Viejo San Juan',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250331-IMG_4386.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250331-IMG_4386.jpg',
     title: 'The group eating at Puerto Criollo in Old San Juan, Puerto Rico',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231662/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2763.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231662/chrisvogt-me/galleries/2025-vsc/20250331-IMG_2763.jpg',
     title: 'Chicken and rice in a mushroom sauce at Puerto Criollo',
     width: 4,
     height: 3
@@ -136,18 +176,24 @@ export const friendsArrivedInSanJuan = [
 export const settingSail = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231667/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2796.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231667/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2796.jpg',
     title: 'Celebrity Equinox, MSC Seascape and Resiliant Lady at port in San Juan',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2799.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2799.jpg',
     title: 'Resiliant Lady at port in San Juan',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2811.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250401-IMG_2811.jpg',
     title: 'Nick celebrating setting sail',
     width: 3,
     height: 4
@@ -157,24 +203,32 @@ export const settingSail = [
 export const earlyShipDays = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231645/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2861.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231645/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2861.jpg',
     title: 'The squad trying on different types of sunglasses',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2835.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2835.jpg',
     title: 'Volleyball on the ship',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231689/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2868.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231689/chrisvogt-me/galleries/2025-vsc/20250403-IMG_2868.jpg',
     title: 'Goofy times at the carousel on the ship',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231648/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2828.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231648/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2828.jpg',
     title: 'The group walking down the stairs to the pool',
     width: 3,
     height: 4
@@ -184,12 +238,16 @@ export const earlyShipDays = [
 export const eatingAtGunbae = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231655/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2831.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231655/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2831.jpg',
     title: 'Eating at Gunbae, a Korean BBQ restaurant on the ship, with Krish',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231687/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2830.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231687/chrisvogt-me/galleries/2025-vsc/20250402-IMG_2830.jpg',
     title: 'The food at Gunbae',
     width: 4,
     height: 3
@@ -199,54 +257,72 @@ export const eatingAtGunbae = [
 export const birdsOfCartagena = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231690/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2883.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231690/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2883.jpg',
     title: 'Birds in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231648/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2895.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231648/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2895.jpg',
     title: 'Birds in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231699/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2907.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231699/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2907.jpg',
     title: 'Indian peafowl — a peacock — in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231649/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2912.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231649/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2912.jpg',
     title: 'A tucan in the port of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2915.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2915.jpg',
     title: 'A golden pheasant (Chrysolophus pictus)',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2918.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2918.jpg',
     title: 'A juvenile scarlet ibis (Eudocimus ruber)',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2922.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2922.jpg',
     title: 'A pair of Peruvian Thick-knees (Hesperoburhinus superciliaris)',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2924.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2924.jpg',
     title: 'White peafowl in Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2926.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2926.jpg',
     title: 'A salmon-crested cockatoo (Cacatua moluccensis)',
     width: 3,
     height: 4
@@ -256,54 +332,72 @@ export const birdsOfCartagena = [
 export const cartagenaStreets = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2939.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2939.jpg',
     title: 'The streets of Getsemaní, Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231676/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3007.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231676/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3007.jpg',
     title: 'Walking around exploring the streets of Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2946.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2946.jpg',
     title: 'Classic, vintage cars in Getsemaní, Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231664/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2949.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231664/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2949.jpg',
     title: 'Castillo San Felipe de Barajast',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231686/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2979.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231686/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2979.jpg',
     title: "It's wine-o-click somewhere",
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231680/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2977.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231680/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2977.jpg',
     title: 'Calle de Las Sombrillas in the Getsemaní neighborhood',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231665/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2942.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231665/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2942.jpg',
     title: 'Street in Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231646/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3033.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231646/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3033.jpg',
     title: 'Street in Cartagena, Colombia at night',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231696/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3037.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231696/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3037.jpg',
     title: 'Stained glass windows in a church',
     width: 3,
     height: 4
@@ -313,24 +407,32 @@ export const cartagenaStreets = [
 export const cartagenaRooftops = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2994.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231637/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2994.jpg',
     title: 'Rooftop view with church',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2997.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231691/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2997.jpg',
     title: 'Rooftop view looking down',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231666/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2987.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231666/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2987.jpg',
     title: 'Another rooftop view from Cartagena, Colombia',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2965.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231673/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2965.jpg',
     title: 'Looking inland from Cartagena, Colombia',
     width: 4,
     height: 3
@@ -340,36 +442,48 @@ export const cartagenaRooftops = [
 export const cartagenaFriends = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2992.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2992.jpg',
     title: 'Nick and Roc',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2991.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231647/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2991.jpg',
     title: 'Matt',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231657/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2960.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231657/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2960.jpg',
     title: 'Happy, hungry Matt',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2962.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250404-IMG_2962.jpg',
     title: 'Blue crab nachos 🤤',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3028.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3028.jpg',
     title: 'Chris and Nick getting seafood for dinner',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3026.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250404-IMG_3026.jpg',
     title: 'A seafood platter in Cartagena, Colombia',
     width: 4,
     height: 3
@@ -379,24 +493,32 @@ export const cartagenaFriends = [
 export const curacaoFriends = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09225.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09225.jpg',
     title: 'Matt up close',
     width: 16,
     height: 9
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-CJV09220.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-CJV09220.jpg',
     title: 'Roc up close',
     width: 16,
     height: 9
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09229.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250407-CJV09229.jpg',
     title: 'Nick up close',
     width: 16,
     height: 9
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3130.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231659/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3130.jpg',
     title: 'The group walking across Queen Emma Bridge',
     width: 3,
     height: 4
@@ -406,30 +528,40 @@ export const curacaoFriends = [
 export const curacaoStreets = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231642/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3127.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231642/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3127.jpg',
     title: 'Queen Emma Bridge in Curaçao',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231654/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3138.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231654/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3138.jpg',
     title: 'Looking across Queen Emma Bridge in Curaçao',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231656/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3123.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231656/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3123.jpg',
     title: 'A variety of different types of Curaçao liqueur',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231696/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3131.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231696/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3131.jpg',
     title: 'Street murals in Curaçao',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231679/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3132.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231679/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3132.jpg',
     title: 'A Dutch newspaper stand in Curaçao',
     width: 3,
     height: 4
@@ -439,54 +571,72 @@ export const curacaoStreets = [
 export const scarletNightAndAtSea = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3153.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3153.jpg',
     title: 'Nick getting his face painted at Scarlet Night',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3162.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231640/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3162.jpg',
     title: 'Nick with his face painted',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231665/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3167.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231665/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3167.jpg',
     title: 'Matt on Scarlet Night',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3173.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3173.jpg',
     title: 'Chris on Scarlet Night',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231694/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3184.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231694/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3184.jpg',
     title: 'The Octopus Garden aboard Resiliant Lady',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3189.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231638/chrisvogt-me/galleries/2025-vsc/20250407-IMG_3189.jpg',
     title: 'The group has drinks at the pool bar on Scarlet Night',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231660/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3248.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231660/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3248.jpg',
     title: 'Chris and Nick at the casino',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250409-IMG_8484.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250409-IMG_8484.jpg',
     title: 'Chris and Nick in the casino',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3274.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250409-IMG_3274.jpg',
     title: 'Matt putting feathers in his hair',
     width: 3,
     height: 4
@@ -496,24 +646,32 @@ export const scarletNightAndAtSea = [
 export const antiguaFirstSpot = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3282.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3282.jpg',
     title: 'Nick looking at a lizard in Antigua',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3287.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231653/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3287.jpg',
     title: "Griswold's ameiva (Pholidoscelis griswoldi) in Antigua",
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231641/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3290.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231641/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3290.jpg',
     title: 'A catamaran docked in St. John’s, Antigua',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3292.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3292.jpg',
     title: "The Captain's Tavern in St. John's, Antigua",
     width: 3,
     height: 4
@@ -523,36 +681,48 @@ export const antiguaFirstSpot = [
 export const antiguaFloatingBar = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231645/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3295.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231645/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3295.jpg',
     title: 'Riding a boat to the floating bar in Dickenson Bay, Antigua',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231680/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3301.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231680/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3301.jpg',
     title: 'Looking into the floating bar',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231657/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3321.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231657/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3321.jpg',
     title: 'Kon Tiki, a floating bar',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231650/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3308.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231650/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3308.jpg',
     title: "Nick doesn't want to leave, ever",
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3350.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231644/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3350.jpg',
     title: 'Looking inland',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3359.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231636/chrisvogt-me/galleries/2025-vsc/20250410-IMG_3359.jpg',
     title: 'Sunset at Kon Tiki, in Dickenson Bay',
     width: 4,
     height: 3
@@ -562,30 +732,40 @@ export const antiguaFloatingBar = [
 export const stMaarten = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231676/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3390.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231676/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3390.jpg',
     title: 'The gang in St. Maarten',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231641/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3409.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231641/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3409.jpg',
     title: 'Happy Nick on a boat in St. Maarten',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231671/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3426.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231671/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3426.jpg',
     title: 'A small boat in the port of St Maarten',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231664/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3412.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231664/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3412.jpg',
     title: 'Resiliant Lady docked in St. Maarten',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3381.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231682/chrisvogt-me/galleries/2025-vsc/20250411-IMG_3381.jpg',
     title: 'Cocktails menu at a beach bar in St. Maarten',
     width: 3,
     height: 4
@@ -595,24 +775,32 @@ export const stMaarten = [
 export const finalSanJuan = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3449.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231652/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3449.jpg',
     title: 'Playa Ocean Park in San Juan, PR',
     width: 3,
     height: 4
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231642/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3522.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231642/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3522.jpg',
     title: 'Looking north from Playa Ocean Park at sunset',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231662/chrisvogt-me/galleries/2025-vsc/20250412-IMG_3446.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231662/chrisvogt-me/galleries/2025-vsc/20250412-IMG_3446.jpg',
     title: 'Dinner at Barbacoa Puerto Rico 🤤',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231688/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3451.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231688/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3451.jpg',
     title: 'The street cats of San Juan, PR',
     width: 3,
     height: 4
@@ -622,18 +810,24 @@ export const finalSanJuan = [
 export const friendsWeMadeInSanJuan = [
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3477.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231668/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3477.jpg',
     title: 'Chris, Tiff and Nick at Condado Beach in San Juan',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231670/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3474.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231670/chrisvogt-me/galleries/2025-vsc/20250413-IMG_3474.jpg',
     title: 'Dancing to disco on Condado Beach while the sun sets',
     width: 4,
     height: 3
   },
   {
     src: 'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,h_900,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3536.jpg',
+    thumb:
+      'https://res.cloudinary.com/chrisvogt/image/upload/c_scale,w_240,f_auto/v1750231685/chrisvogt-me/galleries/2025-vsc/20250418-IMG_3536.jpg',
     title: 'José and Nick on the patio',
     width: 4,
     height: 3


### PR DESCRIPTION
This PR fixes app freezing during window resize operations.

- Add debounced resize handler (100ms)
- Reduce circles from 80 to 40 for performance
- Use viewport height instead of scroll height
- Implement conditional canvas resizing
- Add proper animation cleanup