### PR TITLE
fix: prevent animated background freezing on window resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.45.1
+
+### Performance Improvements
+
+- **Fixed animated background freezing during window resize**: Resolved critical performance issue that caused page freezing and crashes when resizing the browser window or opening DevTools
+- **Optimized resize event handling**: Added 100ms debounce to prevent excessive resize event calls
+- **Reduced rendering overhead**: Decreased animated circle count from 80 to 40 for better performance
+- **Improved canvas sizing**: Replaced expensive `document.body.scrollHeight` calculations with faster `window.innerHeight`
+- **Enhanced memory management**: Added proper animation cleanup with `cancelAnimationFrame`
+
+### Technical Details
+
+- Implemented conditional canvas resizing (only when dimensions actually change)
+- Added circle repositioning logic to maintain bounds after resize
+- All existing functionality preserved with no breaking changes
+
 ## 0.45.0
 
 - Adds a new "Skip to content" link for keyboard-first visitors, allowing them to TAB once on the page and then skip to the <main> content.

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
This PR...

- Add debounced resize handler (100ms)
- Reduce circles from 80 to 40 for performance
- Use viewport height instead of scroll height
- Implement conditional canvas resizing
- Add proper animation cleanup

Fixes app freezing during window resize operations.