### PR TITLE
feat: split home content into new /about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.45.2
+
+— Splits the Home page content out into a new About Me page at /about/.
+
 ## 0.45.1
 
 ### Performance Improvements

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/home-header-content.js
+++ b/theme/src/components/home-header-content.js
@@ -51,24 +51,13 @@ const HomeHeaderContent = () => {
 
       <Themed.p>
         This is my personal blog and digital garden: a place where I share what I’m building, exploring, and learning
-        over time.
+        over time. This space is always evolving — part notebook, part playground — and I’m glad you found your way
+        here.
       </Themed.p>
 
       <Themed.p>
-        By day, I work as a software engineer at GoDaddy, creating tools that help small businesses build, grow, and
-        understand their online presence. But this site isn’t about work — it’s where I follow my curiosity, experiment
-        with ideas, and write code just for fun.
-      </Themed.p>
-
-      <Themed.p>
-        Most evenings, you’ll find me at the piano — practicing, recording, or just playing around with sound. I’ve been
-        slowly teaching myself music, and I’m figuring out how to bring what I know from tech into making music. I also
-        spend a lot of time with friends in the city and love connecting with people who are passionate about what they
-        do.
-      </Themed.p>
-
-      <Themed.p>
-        This space is always evolving — part notebook, part playground — and I’m glad you found your way here.
+        This page is a dashboard of my posts and online activity. The social content below is updated automatically
+        every day.
       </Themed.p>
     </div>
   )

--- a/theme/src/components/home-header-content.spec.js
+++ b/theme/src/components/home-header-content.spec.js
@@ -10,18 +10,13 @@ describe('HomeHeaderContent', () => {
     // Check for the main headline
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent("Hi! 👋 I'm Chris Vogt.")
 
-    // Check for the paragraphs
+    // Check for the first paragraph about the blog and digital garden
     expect(screen.getByText(/This is my personal blog and digital garden/i)).toBeInTheDocument()
-    expect(screen.getByText(/I work as a software engineer at GoDaddy/i)).toBeInTheDocument()
-
-    // Use a more flexible text matcher for the piano paragraph
-    const pianoParagraph = screen.getByText(
-      (content, element) =>
-        element.tagName.toLowerCase() === 'p' && content.includes('Most evenings') && content.includes('piano')
-    )
-    expect(pianoParagraph).toBeInTheDocument()
-
     expect(screen.getByText(/This space is always evolving/i)).toBeInTheDocument()
+
+    // Check for the second paragraph about the dashboard
+    expect(screen.getByText(/This page is a dashboard of my posts and online activity/i)).toBeInTheDocument()
+    expect(screen.getByText(/The social content below is updated automatically every day/i)).toBeInTheDocument()
   })
 
   it('applies wobble animation to emoji on mouse enter', () => {

--- a/theme/src/data/navigation.json
+++ b/theme/src/data/navigation.json
@@ -4,6 +4,12 @@
     "header": {
       "left": [
         {
+          "path": "/about",
+          "slug": "about",
+          "text": "About",
+          "title": "About Me — Chris Vogt"
+        },
+        {
           "path": "/blog",
           "slug": "blog",
           "text": "Blog",

--- a/theme/src/templates/home.js
+++ b/theme/src/templates/home.js
@@ -66,7 +66,7 @@ const HomeTemplate = () => (
 
 export const Head = () => (
   <Seo
-    title='Chris Vogt - Software Engineer in San Francisco | Digital Garden of Photography, Piano, and Travel'
+    title='Chris Vogt - Software Engineer in San Francisco | Photography, Piano, and Travel Blog'
     description="Explore Chris Vogt's digital garden. A Software Engineer in San Francisco, Chris shares his interest in photography, piano, and travel."
     keywords='Chris Vogt, Software Engineer in San Francisco, GoDaddy engineer blog, photography blog, piano recordings, travel blog, personal blog, digital garden'
   >

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",

--- a/www.chrisvogt.me/src/pages/about.js
+++ b/www.chrisvogt.me/src/pages/about.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Container, Flex } from 'theme-ui'
+import { Themed } from '@theme-ui/mdx'
+import Layout from 'gatsby-theme-chrisvogt/src/components/layout'
+import Seo from 'gatsby-theme-chrisvogt/src/components/seo'
+
+const AboutPage = () => {
+  return (
+    <Layout>
+      <Flex
+        sx={{
+          flexDirection: 'column',
+          flexGrow: 1,
+          position: 'relative',
+          py: 3
+        }}
+      >
+        <Container sx={{ width: ['', '', 'max(80ch, 50vw)'], lineHeight: 1.7 }}>
+          <Themed.h1>About Me</Themed.h1>
+
+          <Themed.p>
+            By day, I work as a software engineer at GoDaddy, creating tools that help small businesses build, grow, and
+            understand their online presence. But this site isn’t about work — it’s where I follow my curiosity,
+            experiment with ideas, and write code just for fun.
+          </Themed.p>
+
+          <Themed.p>
+            Most evenings, you’ll find me at the piano — practicing, recording, or just playing around with sound. I’ve
+            been slowly teaching myself music, and I’m figuring out how to bring what I know from tech into making
+            music. I also spend a lot of time with friends in the city and love connecting with people who are
+            passionate about what they do.
+          </Themed.p>
+        </Container>
+      </Flex>
+    </Layout>
+  )
+}
+
+export const Head = () => <Seo title='About Me' />
+
+export default AboutPage


### PR DESCRIPTION
This PR splits part of the Home page content into a new route at /about/.

## AI summary

This pull request updates the homepage content, adds a new "About" page, and adjusts navigation and metadata to align with the changes. The most important changes include simplifying the homepage text, adding a dedicated "About" page, updating navigation links, and refining the page metadata.

### Homepage Updates:
* Simplified the homepage text to focus on the blog's purpose as a dashboard for posts and online activity. Removed personal and professional details that were moved to the new "About" page. (`theme/src/components/home-header-content.js`)
* Updated the corresponding tests to reflect the new homepage content structure. Removed checks for the deleted paragraphs and added tests for the new dashboard-related text. (`theme/src/components/home-header-content.spec.js`)

### New "About" Page:
* Added a new `About` page with detailed personal and professional information, including work at GoDaddy, music interests, and personal connections. (`www.chrisvogt.me/src/pages/about.js`)

### Navigation Updates:
* Added a new "About" link to the navigation menu to allow users to access the new page. (`theme/src/data/navigation.json`)

### Metadata Updates:
* Updated the homepage SEO title to better reflect the blog's focus on photography, piano, and travel, removing redundant mentions of "digital garden." (`theme/src/templates/home.js`)