### PR TITLE
content: adds a new /now page any my first article for it

### DIFF
--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.js
@@ -12,7 +12,7 @@ import Widget from '../widget'
 import WidgetHeader from '../widget-header'
 
 export default () => {
-  const posts = useRecentPosts()
+  const posts = useRecentPosts(2)
 
   const getColumnCount = postsCount => {
     let columnCount

--- a/theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js
+++ b/theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js
@@ -26,6 +26,12 @@ describe('RecentPostsWidget', () => {
     jest.clearAllMocks()
   })
 
+  it('calls useRecentPosts with limit of 2', () => {
+    useRecentPosts.mockReturnValue([])
+    render(<RecentPostsWidget />)
+    expect(useRecentPosts).toHaveBeenCalledWith(2)
+  })
+
   it('renders a grid with one post', () => {
     useRecentPosts.mockReturnValue([
       {

--- a/theme/src/data/navigation.json
+++ b/theme/src/data/navigation.json
@@ -10,6 +10,12 @@
           "title": "About Me — Chris Vogt"
         },
         {
+          "path": "/now",
+          "slug": "now",
+          "text": "Now",
+          "title": "What I'm up to"
+        },
+        {
           "path": "/blog",
           "slug": "blog",
           "text": "Blog",

--- a/theme/src/hooks/use-recent-posts.js
+++ b/theme/src/hooks/use-recent-posts.js
@@ -1,15 +1,15 @@
 import { useStaticQuery, graphql } from 'gatsby'
 
-export const getPosts = queryResult => {
+export const getPosts = (queryResult, limit = null) => {
   const { allMdx: { edges = [] } = {} } = queryResult
-  const recentPosts = edges.map(({ node }) => node)
-  return recentPosts
+  const recentPosts = edges.map(({ node }) => node).filter(node => node.frontmatter.slug !== 'now')
+  return limit ? recentPosts.slice(0, limit) : recentPosts
 }
 
-const useRecentPosts = () => {
+const useRecentPosts = (limit = null) => {
   const queryResult = useStaticQuery(graphql`
     query RecentPosts {
-      allMdx(limit: 2, sort: { frontmatter: { date: DESC } }) {
+      allMdx(limit: 3, sort: { frontmatter: { date: DESC } }) {
         edges {
           node {
             excerpt(pruneLength: 255)
@@ -32,7 +32,7 @@ const useRecentPosts = () => {
     }
   `)
 
-  const recentPosts = getPosts(queryResult)
+  const recentPosts = getPosts(queryResult, limit)
   return recentPosts
 }
 

--- a/theme/src/hooks/use-recent.posts.spec.js
+++ b/theme/src/hooks/use-recent.posts.spec.js
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks'
 import { useStaticQuery } from 'gatsby'
-import useRecentPosts from './use-recent-posts'
+import useRecentPosts, { getPosts } from './use-recent-posts'
 
 const data = {
   allMdx: {
@@ -15,7 +15,38 @@ const data = {
           },
           frontmatter: {
             banner: 'https://placekitten.com/300/300',
-            title: 'A Blog Article'
+            title: 'A Blog Article',
+            slug: 'a-blog-article'
+          }
+        }
+      },
+      {
+        node: {
+          excerpt: 'Another interesting post!',
+          fields: {
+            id: 'post-identifier-2',
+            category: 'general',
+            slug: 'another-article'
+          },
+          frontmatter: {
+            banner: 'https://placekitten.com/300/300',
+            title: 'Another Article',
+            slug: 'another-article'
+          }
+        }
+      },
+      {
+        node: {
+          excerpt: 'A now page post',
+          fields: {
+            id: 'now-post',
+            category: 'general',
+            slug: 'now'
+          },
+          frontmatter: {
+            banner: 'https://placekitten.com/300/300',
+            title: 'Now Page',
+            slug: 'now'
           }
         }
       }
@@ -39,8 +70,30 @@ describe('useRecentPosts', () => {
     expect(result.current).toEqual([
       {
         ...data.allMdx.edges[0].node
+      },
+      {
+        ...data.allMdx.edges[1].node
       }
     ])
+  })
+
+  it('filters out posts with slug "now"', () => {
+    const { result } = renderHook(() => useRecentPosts())
+    const nowPost = result.current.find(post => post.frontmatter.slug === 'now')
+    expect(nowPost).toBeUndefined()
+  })
+
+  it('returns limited posts when limit is provided', () => {
+    const { result } = renderHook(() => useRecentPosts(1))
+    expect(result.current).toHaveLength(1)
+    expect(result.current[0]).toEqual({
+      ...data.allMdx.edges[0].node
+    })
+  })
+
+  it('returns all posts when limit is null', () => {
+    const { result } = renderHook(() => useRecentPosts(null))
+    expect(result.current).toHaveLength(2) // Excluding the 'now' post
   })
 
   it('handles missing allMdx', () => {
@@ -59,5 +112,46 @@ describe('useRecentPosts', () => {
     useStaticQuery.mockImplementation(() => ({ allMdx: { edges: [] } }))
     const { result } = renderHook(() => useRecentPosts())
     expect(result.current).toEqual([])
+  })
+})
+
+describe('getPosts', () => {
+  it('returns all posts when no limit is provided', () => {
+    const result = getPosts(data)
+    expect(result).toHaveLength(2) // Excluding the 'now' post
+    expect(result[0].frontmatter.slug).toBe('a-blog-article')
+    expect(result[1].frontmatter.slug).toBe('another-article')
+  })
+
+  it('returns limited posts when limit is provided', () => {
+    const result = getPosts(data, 1)
+    expect(result).toHaveLength(1)
+    expect(result[0].frontmatter.slug).toBe('a-blog-article')
+  })
+
+  it('filters out posts with slug "now"', () => {
+    const result = getPosts(data)
+    const nowPost = result.find(post => post.frontmatter.slug === 'now')
+    expect(nowPost).toBeUndefined()
+  })
+
+  it('handles empty query result', () => {
+    const result = getPosts({})
+    expect(result).toEqual([])
+  })
+
+  it('handles query result with no allMdx', () => {
+    const result = getPosts({ someOtherData: [] })
+    expect(result).toEqual([])
+  })
+
+  it('handles query result with no edges', () => {
+    const result = getPosts({ allMdx: {} })
+    expect(result).toEqual([])
+  })
+
+  it('handles query result with empty edges array', () => {
+    const result = getPosts({ allMdx: { edges: [] } })
+    expect(result).toEqual([])
   })
 })

--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx
@@ -1,0 +1,98 @@
+---
+title: 'Now — June 2025 Recap'
+slug: now
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1750657869/chrisvogt-me/thumbnails/june-2025-banner-placeholder.webp
+date: '2025-06-29T14:00:00.000Z'
+description: >
+  A personal recap of what I've been working on, exploring, and thinking about in June 2025.
+excerpt: >
+  A roundup of June 2025—projects, travel, thoughts, and the little things in between.
+keywords: [june 2025, personal blog, monthly recap, chris vogt, software projects, music practice, travel highlights]
+---
+
+This post is my first now page article, and a look back at what I've been up to this month.
+
+## ✨ Highlights
+
+This month the theme has been revisiting and updating personal projects. Some that I hadn't worked on in 8 years!
+
+AI is front and center at work right now. My projects this month have all related to logged-in customer navigation and AI experiences. I feel lucky to be working for a company that is embracing AI tools for developers and applying AI to products.
+
+I've also started using [Cursor](https://www.cursor.com/) both at home and at work instead of VS Code, and have been using it to improve the code coverage for this project and the API behind it.
+
+Finally — I'm preparing for a short vacation coming up next month. In July I'll spend 5 days in Puerto Vallarta, Mexico.
+
+## 🛠️ What I Worked On
+
+### Reviving teachersalary.info
+
+Early in the month, I noticed that [teachersalary.info](https://teachersalary.info) was receiving more traffic than I expected — more than this blog even! — and so I spent the first time in 8 years updating the project. I published [a blog post](/personal/teacher-salary-info/) sharing the project.
+
+### Published a new Steam widget to my home page
+
+I've have a PR staged that explored connecting to the Steam API, and in June 2025 I deployed that and published a new Steam widget on [my home page](/) that renders the top-ten games I've played overall, by hour, as a table, and links to my Steam profile to review the rest.
+
+I've been chatting with a few people about the project and how it could be improved, by growing the visualizations and data sets beyond this first example. If you have any ideas or feedback, let me know.
+
+### Replaces TravisCI and CircleCI with GitHub Actions
+
+Across all of my projects, I've been working to replace CircleCI and TravisCI with GitHub Actions. I can drive my entire CI pipeline for most of my projects using entirely GitHub Actions and don't need the complexity of the additional services.
+
+### Updates to my Personal API
+
+I've been putting more attention into my personal API behind this website, metrics.chrisvogt.me. I added the [first set of unit tests](https://github.com/chrisvogt/metrics/pull/61) using vitest, [migrated from Firebase Functions v1](https://github.com/chrisvogt/metrics/pull/58) to v2, and made changes to [optimize my responses](https://github.com/chrisvogt/metrics/pull/59) and improve my site's performance.
+
+## 🎹 Music & Creativity
+
+This month I added several new songs to my practice rotation and updated [https://repertoire.chrisvogt.me](repertoire.chrisvogt.me) to include them. Here's what I've been playing:
+
+<Table>
+  <thead>
+    <tr>
+      <th>Song</th>
+      <th>Artist</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Twilight Zone</td>
+      <td>Ariana Grande</td>
+    </tr>
+    <tr>
+      <td>The Way We Were</td>
+      <td>Barbara Streisand</td>
+    </tr>
+    <tr>
+      <td>Broken</td>
+      <td>Lovelytheband</td>
+    </tr>
+    <tr>
+      <td>Touch</td>
+      <td>Daft Punk</td>
+    </tr>
+    <tr>
+      <td>I Think They Call This Love</td>
+      <td>Elliot James Reay</td>
+    </tr>
+    <tr>
+      <td>Golden Hour</td>
+      <td>JVKE</td>
+    </tr>
+    <tr>
+      <td>Pink Pony Club</td>
+      <td>Chappell Roan</td>
+    </tr>
+    <tr>
+      <td>Till Forever Falls Apart</td>
+      <td>Ashe & FINNEAS</td>
+    </tr>
+  </tbody>
+</Table>
+
+## 📚 What I Read
+
+This month I read [49 pages (16%) of _Flowers for Algernon_](https://www.goodreads.com/user_status/show/1076801541). The bulk of my reading is done while in transit and I'm working on habits to spend time reading outside of that.
+
+## 💭 Final Thoughts
+
+This is the first time I've used this format, and have published [a now page](https://nownownow.com/about). When I create my next one, I'll move this article to a new location to archive it.

--- a/www.chrisvogt.me/src/pages/blog.js
+++ b/www.chrisvogt.me/src/pages/blog.js
@@ -12,7 +12,12 @@ import Seo from '../../../theme/src/components/seo'
 
 const BlogIndexPage = ({ data }) => {
   const posts = getPosts(data)?.filter(
-    post => !(post.fields.category?.startsWith('photography') || post.fields.category?.startsWith('music'))
+    post =>
+      !(
+        post.fields.category?.startsWith('photography') ||
+        post.fields.category?.startsWith('music') ||
+        post.frontmatter.slug === 'now'
+      )
   )
 
   return (

--- a/www.chrisvogt.me/src/pages/blog.spec.js
+++ b/www.chrisvogt.me/src/pages/blog.spec.js
@@ -1,0 +1,140 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import BlogIndexPage from './blog'
+
+// Mock the components
+jest.mock('../../../theme/src/components/layout', () => ({ children }) => <div data-testid='layout'>{children}</div>)
+jest.mock('../../../theme/src/components/blog/page-header', () => ({ children }) => <h1>{children}</h1>)
+jest.mock('../../../theme/src/components/widgets/recent-posts/post-card', () => ({ title, category }) => (
+  <div data-testid='post-card' data-category={category}>
+    {title}
+  </div>
+))
+jest.mock('../../../theme/src/components/seo', () => () => <div data-testid='seo' />)
+
+// Mock the getPosts function
+jest.mock('../../../theme/src/hooks/use-recent-posts', () => ({
+  getPosts: jest.fn()
+}))
+
+import { getPosts } from '../../../theme/src/hooks/use-recent-posts'
+
+describe('BlogIndexPage', () => {
+  const mockPosts = [
+    {
+      frontmatter: {
+        title: 'Regular Blog Post',
+        slug: 'regular-post'
+      },
+      fields: {
+        category: 'blog',
+        id: '1',
+        path: '/blog/regular-post'
+      }
+    },
+    {
+      frontmatter: {
+        title: 'Now Page Post',
+        slug: 'now'
+      },
+      fields: {
+        category: 'blog',
+        id: '2',
+        path: '/blog/now'
+      }
+    },
+    {
+      frontmatter: {
+        title: 'Photography Post',
+        slug: 'photography-post'
+      },
+      fields: {
+        category: 'photography',
+        id: '3',
+        path: '/photography/photography-post'
+      }
+    },
+    {
+      frontmatter: {
+        title: 'Music Post',
+        slug: 'music-post'
+      },
+      fields: {
+        category: 'music',
+        id: '4',
+        path: '/music/music-post'
+      }
+    }
+  ]
+
+  beforeEach(() => {
+    getPosts.mockReturnValue(mockPosts)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the blog page with filtered posts', () => {
+    render(<BlogIndexPage data={{}} />)
+
+    // Should render the layout
+    expect(screen.getByTestId('layout')).toBeInTheDocument()
+
+    // Should render the page header
+    expect(screen.getByText('Blog Posts')).toBeInTheDocument()
+
+    // Should render only the regular blog post (filtered out: now, photography, music)
+    const postCards = screen.getAllByTestId('post-card')
+    expect(postCards).toHaveLength(1)
+    expect(postCards[0]).toHaveTextContent('Regular Blog Post')
+  })
+
+  it('filters out posts with slug "now"', () => {
+    render(<BlogIndexPage data={{}} />)
+
+    const postCards = screen.getAllByTestId('post-card')
+    const nowPost = postCards.find(card => card.textContent === 'Now Page Post')
+    expect(nowPost).toBeUndefined()
+  })
+
+  it('filters out photography posts', () => {
+    render(<BlogIndexPage data={{}} />)
+
+    const postCards = screen.getAllByTestId('post-card')
+    const photographyPost = postCards.find(card => card.textContent === 'Photography Post')
+    expect(photographyPost).toBeUndefined()
+  })
+
+  it('filters out music posts', () => {
+    render(<BlogIndexPage data={{}} />)
+
+    const postCards = screen.getAllByTestId('post-card')
+    const musicPost = postCards.find(card => card.textContent === 'Music Post')
+    expect(musicPost).toBeUndefined()
+  })
+
+  it('handles empty posts array', () => {
+    getPosts.mockReturnValue([])
+    render(<BlogIndexPage data={{}} />)
+
+    const postCards = screen.queryAllByTestId('post-card')
+    expect(postCards).toHaveLength(0)
+  })
+
+  it('handles null posts', () => {
+    getPosts.mockReturnValue(null)
+    render(<BlogIndexPage data={{}} />)
+
+    const postCards = screen.queryAllByTestId('post-card')
+    expect(postCards).toHaveLength(0)
+  })
+
+  it('calls getPosts with the provided data', () => {
+    const mockData = { someData: 'value' }
+    render(<BlogIndexPage data={mockData} />)
+
+    expect(getPosts).toHaveBeenCalledWith(mockData)
+  })
+})


### PR DESCRIPTION
This PR adds a [now page](https://nownownow.com/about) to my website.

## AI summary

This pull request introduces a "Now" page feature and updates the recent posts functionality, including filtering, limiting, and testing. It also adds a new blog post and updates the blog page to handle the "Now" page. Below is a summary of the most important changes grouped by theme.

### Recent Posts Enhancements
* Updated `useRecentPosts` to support filtering out posts with the slug "now" and to accept a `limit` parameter for returning a specific number of posts. The default limit was increased to 3 (`theme/src/hooks/use-recent-posts.js`). [[1]](diffhunk://#diff-86c0454cf9d86d8780b43fd0fe04712e2ee83428a29701aba403dc317812631cL3-R12) [[2]](diffhunk://#diff-86c0454cf9d86d8780b43fd0fe04712e2ee83428a29701aba403dc317812631cL35-R35)
* Added corresponding tests for `useRecentPosts` and the new `getPosts` utility function to validate filtering, limiting, and edge cases (`theme/src/hooks/use-recent.posts.spec.js`). [[1]](diffhunk://#diff-b09400c8787fae665ee997452a123bd9cd7dcd169449561a216a3c140fed8eb5R73-R98) [[2]](diffhunk://#diff-b09400c8787fae665ee997452a123bd9cd7dcd169449561a216a3c140fed8eb5R117-R157)

### Recent Posts Widget Updates
* Modified the `RecentPostsWidget` component to pass a limit of 2 to `useRecentPosts` and added a test to ensure this behavior (`theme/src/components/widgets/recent-posts/recent-posts-widget.js`, `theme/src/components/widgets/recent-posts/recent-posts-widget.spec.js`). [[1]](diffhunk://#diff-e025ffcc9f038147fc2610b73b6d90b1d405705d2ae9a087d012f7550d0b7751L15-R15) [[2]](diffhunk://#diff-9276032f140f7109bae9743dbbaf73bb3cdc78952a0d8ecc39264b0b7cf5f8bbR29-R34)

### Blog Page Updates
* Updated the blog page to filter out posts with the slug "now" in addition to photography and music posts (`www.chrisvogt.me/src/pages/blog.js`).
* Added tests for the blog page to ensure proper filtering of "now," photography, and music posts, as well as handling of empty or null posts (`www.chrisvogt.me/src/pages/blog.spec.js`).

### Navigation and Content Additions
* Added a "Now" page link to the navigation menu (`theme/src/data/navigation.json`).
* Created a new blog post titled "Now — June 2025 Recap" to serve as the first "Now" page article (`www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx`).