### PR TITLE
fix: replace banner on /now article and correct date

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx
@@ -1,8 +1,8 @@
 ---
 title: 'Now — June 2025 Recap'
 slug: now
-banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1750657869/chrisvogt-me/thumbnails/june-2025-banner-placeholder.webp
-date: '2025-06-29T14:00:00.000Z'
+banner: https://res.cloudinary.com/chrisvogt/image/upload/f_auto/v1751343485/chrisvogt-me/thumbnails/now-page.webp
+date: '2025-06-30T14:00:00.000Z'
 description: >
   A personal recap of what I've been working on, exploring, and thinking about in June 2025.
 excerpt: >


### PR DESCRIPTION
This PR adds a custom banner image for the Now page article while also correcting the date to reflect today, June 30.

## AI summary

This pull request updates the metadata of the June 2025 recap blog post to reflect a new banner image and an updated publication date.

Content updates:

* [`www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx`](diffhunk://#diff-1bc82d0f8b02fa5472c90c2bdb063adaf09b98d5c0a7274c95b82593bc8ee07eL4-R5): Updated the `banner` URL to use a new image (`now-page.webp`) and changed the `date` to reflect the corrected publication date of June 30, 2025.