### PR TITLE
fix: invalid link in latest blog post

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap.mdx
@@ -44,7 +44,7 @@ I've been putting more attention into my personal API behind this website, metri
 
 ## 🎹 Music & Creativity
 
-This month I added several new songs to my practice rotation and updated [https://repertoire.chrisvogt.me](repertoire.chrisvogt.me) to include them. Here's what I've been playing:
+This month I added several new songs to my practice rotation and updated [repertoire.chrisvogt.me](https://repertoire.chrisvogt.me) to include them. Here's what I've been playing:
 
 <Table>
   <thead>


### PR DESCRIPTION
This PR fixes a typo in one of my blog post links – leading visitors to a 404 page!