### PR TITLE
fix: book progress on Now page

### DIFF
--- a/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
+++ b/www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx
@@ -148,7 +148,7 @@ I added several new songs to my practice rotation this month and updated [repert
 
 ## 📚 What I Read
 
-I started reading [_Flowers for Algernon_](https://www.goodreads.com/user_status/show/1076801541) this month — I'm about 49 pages in (16%). I usually read while traveling, but I'm working on building a habit of reading more during quiet moments at home.
+I made progress on [_Flowers for Algernon_](https://www.goodreads.com/user_status/show/1076801541) this month — I’m now on page 226 of 311 (about 73%). I still do most of my reading while traveling, but I’ve been trying to carve out more quiet time at home to read.
 
 ---
 


### PR DESCRIPTION
I used ChatGPT to proofread and polish my blog post, obviously. And it hallucinated the book progress here. 🤦‍♂️

## AI summary

This pull request updates the blog post for June 2025 to reflect progress on the book "Flowers for Algernon."

Content updates:

* [`www.chrisvogt.me/content/blog/2025-06-30-june-2025-recap/2025-06-30-june-2025-recap.mdx`](diffhunk://#diff-2301b7fd9318eb0ea5b44cf7dde6176a140ad5384d58900878c27caedf766edaL151-R151): Updated the reading progress on "Flowers for Algernon" from 16% (49 pages) to 73% (226 pages) and added a note about efforts to read more at home.