### PR TITLE
feat: add h-entry microformats markup to blog post templates

### DIFF
--- a/theme/src/components/h-card.js
+++ b/theme/src/components/h-card.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 const HCard = () => (
   <div className='h-card' style={{ display: 'none' }}>
-    <a className='p-name' href='https://www.chrisvogt.me'>
+    <a className='p-name u-url u-uid' href='https://www.chrisvogt.me' rel='me'>
       Chris Vogt
     </a>
     <img
@@ -25,6 +25,7 @@ const HCard = () => (
       CA
     </abbr>
     <div className='p-country-name'>U.S.A</div>
+    <div class='p-category'>Software Developer</div>
   </div>
 )
 

--- a/theme/src/templates/__snapshots__/media.spec.js.snap
+++ b/theme/src/templates/__snapshots__/media.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Media Post renders correctly with a SoundCloud source 1`] = `
 <div
@@ -12,6 +12,7 @@ exports[`Media Post renders correctly with a SoundCloud source 1`] = `
     >
       <article
         className="h-entry"
+        id="mock-media-id"
       >
         <div
           className="css-1blzwpa"
@@ -29,6 +30,53 @@ exports[`Media Post renders correctly with a SoundCloud source 1`] = `
           Published 
           Mon, 17 Jun 2024 03:30:26 GMT
         </time>
+        <div
+          style={
+            {
+              "display": "none",
+            }
+          }
+        >
+          <a
+            className="u-url"
+            href="https://www.chrisvogt.me/music/mock-media"
+          />
+          <span
+            className="u-uid"
+          >
+            mock-media-id
+          </span>
+          <div
+            className="p-summary"
+          >
+            Mock Description
+          </div>
+          <img
+            alt=""
+            className="u-photo"
+            src="mock-banner.jpg"
+          />
+          <span
+            className="p-category"
+          >
+            Mock Category
+          </span>
+          <span
+            className="p-category"
+          >
+            mock
+          </span>
+          <span
+            className="p-category"
+          >
+            test
+          </span>
+          <span
+            className="p-category"
+          >
+            music
+          </span>
+        </div>
         <div
           className="e-content article-content"
         >
@@ -67,6 +115,7 @@ exports[`Media Post renders correctly with a YouTube source 1`] = `
     >
       <article
         className="h-entry"
+        id="mock-media-id"
       >
         <div
           className="css-1blzwpa"
@@ -84,6 +133,53 @@ exports[`Media Post renders correctly with a YouTube source 1`] = `
           Published 
           Mon, 17 Jun 2024 03:30:26 GMT
         </time>
+        <div
+          style={
+            {
+              "display": "none",
+            }
+          }
+        >
+          <a
+            className="u-url"
+            href="https://www.chrisvogt.me/music/mock-media"
+          />
+          <span
+            className="u-uid"
+          >
+            mock-media-id
+          </span>
+          <div
+            className="p-summary"
+          >
+            Mock Description
+          </div>
+          <img
+            alt=""
+            className="u-photo"
+            src="mock-banner.jpg"
+          />
+          <span
+            className="p-category"
+          >
+            Mock Category
+          </span>
+          <span
+            className="p-category"
+          >
+            mock
+          </span>
+          <span
+            className="p-category"
+          >
+            test
+          </span>
+          <span
+            className="p-category"
+          >
+            music
+          </span>
+        </div>
         <div
           className="e-content article-content"
         >
@@ -109,6 +205,7 @@ exports[`Media Post renders correctly with no media sources 1`] = `
     >
       <article
         className="h-entry"
+        id="mock-media-id"
       >
         <div
           className="css-1blzwpa"
@@ -126,6 +223,53 @@ exports[`Media Post renders correctly with no media sources 1`] = `
           Published 
           Mon, 17 Jun 2024 03:30:26 GMT
         </time>
+        <div
+          style={
+            {
+              "display": "none",
+            }
+          }
+        >
+          <a
+            className="u-url"
+            href="https://www.chrisvogt.me/music/mock-media"
+          />
+          <span
+            className="u-uid"
+          >
+            mock-media-id
+          </span>
+          <div
+            className="p-summary"
+          >
+            Mock Description
+          </div>
+          <img
+            alt=""
+            className="u-photo"
+            src="mock-banner.jpg"
+          />
+          <span
+            className="p-category"
+          >
+            Mock Category
+          </span>
+          <span
+            className="p-category"
+          >
+            mock
+          </span>
+          <span
+            className="p-category"
+          >
+            test
+          </span>
+          <span
+            className="p-category"
+          >
+            music
+          </span>
+        </div>
         <div
           className="e-content article-content"
         >

--- a/theme/src/templates/__snapshots__/post.spec.js.snap
+++ b/theme/src/templates/__snapshots__/post.spec.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Blog Post does not render category when not provided 1`] = `
 <div
@@ -12,6 +12,7 @@ exports[`Blog Post does not render category when not provided 1`] = `
     >
       <article
         className="h-entry c1v0-blog-post"
+        id="mock-post-id"
       >
         <h1
           className="p-name css-1sus4jf"
@@ -27,6 +28,48 @@ exports[`Blog Post does not render category when not provided 1`] = `
             Published 
             Mon, 17 Jun 2024 03:30:26 GMT
           </time>
+        </div>
+        <div
+          style={
+            {
+              "display": "none",
+            }
+          }
+        >
+          <a
+            className="u-url"
+            href="https://www.chrisvogt.me/blog/mock-post"
+          />
+          <span
+            className="u-uid"
+          >
+            mock-post-id
+          </span>
+          <div
+            className="p-summary"
+          >
+            This is a mock description
+          </div>
+          <img
+            alt=""
+            className="u-photo"
+            src="mock-banner.jpg"
+          />
+          <span
+            className="p-category"
+          >
+            mock
+          </span>
+          <span
+            className="p-category"
+          >
+            test
+          </span>
+          <span
+            className="p-category"
+          >
+            blog
+          </span>
         </div>
         <div
           className="e-content article-content"
@@ -53,6 +96,7 @@ exports[`Blog Post matches the snapshot 1`] = `
     >
       <article
         className="h-entry c1v0-blog-post"
+        id="mock-post-id"
       >
         <div
           className="css-1blzwpa"
@@ -73,6 +117,53 @@ exports[`Blog Post matches the snapshot 1`] = `
             Published 
             Mon, 17 Jun 2024 03:30:26 GMT
           </time>
+        </div>
+        <div
+          style={
+            {
+              "display": "none",
+            }
+          }
+        >
+          <a
+            className="u-url"
+            href="https://www.chrisvogt.me/blog/mock-post"
+          />
+          <span
+            className="u-uid"
+          >
+            mock-post-id
+          </span>
+          <div
+            className="p-summary"
+          >
+            This is a mock description
+          </div>
+          <img
+            alt=""
+            className="u-photo"
+            src="mock-banner.jpg"
+          />
+          <span
+            className="p-category"
+          >
+            Mock Category
+          </span>
+          <span
+            className="p-category"
+          >
+            mock
+          </span>
+          <span
+            className="p-category"
+          >
+            test
+          </span>
+          <span
+            className="p-category"
+          >
+            blog
+          </span>
         </div>
         <div
           className="e-content article-content"

--- a/theme/src/templates/media.js
+++ b/theme/src/templates/media.js
@@ -24,6 +24,13 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
   const soundcloudId = mdx.frontmatter.soundcloudId
   const title = getTitle(mdx)
   const youtubeSrc = mdx.frontmatter.youtubeSrc
+  const description = getDescription(mdx)
+  const banner = getBanner(mdx)
+  const keywords = mdx.frontmatter.keywords
+  const path = mdx.fields.path
+
+  // Build canonical URL
+  const canonicalUrl = `https://www.chrisvogt.me${path}`
 
   // Set the SoundCloud track in Redux when this component mounts
   useEffect(() => {
@@ -58,12 +65,27 @@ const MediaTemplate = ({ data: { mdx }, children }) => {
         }}
       >
         <Container sx={{ width: ['', 'max(80ch, 50vw)'], lineHeight: 1.7 }}>
-          <article className='h-entry'>
+          <article className='h-entry' id={mdx.id}>
             {category && <Category type={category} sx={{ mb: 2 }} />}
 
             <PageHeader>{title}</PageHeader>
 
             <time className='dt-published created'>Published {date}</time>
+
+            {/* Hidden microformats data */}
+            <div style={{ display: 'none' }}>
+              <a className='u-url' href={canonicalUrl} />
+              <span className='u-uid'>{mdx.id}</span>
+              {description && <div className='p-summary'>{description}</div>}
+              {banner && <img className='u-photo' src={banner} alt='' />}
+              {category && <span className='p-category'>{category}</span>}
+              {keywords &&
+                keywords.map((keyword, index) => (
+                  <span key={index} className='p-category'>
+                    {keyword}
+                  </span>
+                ))}
+            </div>
 
             <div className='e-content article-content'>{children}</div>
           </article>
@@ -85,13 +107,16 @@ export const pageQuery = graphql`
   query ($id: String!) {
     mdx(fields: { id: { eq: $id } }) {
       body
+      id
       fields {
         category
+        path
       }
       frontmatter {
         banner
         date(formatString: "MMMM DD, YYYY")
         description
+        keywords
         title
         type
         soundcloudId

--- a/theme/src/templates/media.spec.js
+++ b/theme/src/templates/media.spec.js
@@ -10,8 +10,10 @@ import Media, { Head } from './media'
 // Mocked Data
 const data = {
   mdx: {
+    id: 'mock-media-id',
     fields: {
-      category: 'Mock Category'
+      category: 'Mock Category',
+      path: '/music/mock-media'
     },
     frontmatter: {
       title: 'A Mock Blog Post',
@@ -19,7 +21,8 @@ const data = {
       soundcloudId: null,
       youtubeSrc: null,
       banner: 'mock-banner.jpg',
-      description: 'Mock Description'
+      description: 'Mock Description',
+      keywords: ['mock', 'test', 'music']
     }
   }
 }

--- a/theme/src/templates/post.js
+++ b/theme/src/templates/post.js
@@ -14,12 +14,19 @@ const PostTemplate = ({ children, data }) => {
   const category = mdx.fields.category
   const date = mdx.frontmatter.date
   const title = mdx.frontmatter.title
+  const description = mdx.frontmatter.description
+  const banner = mdx.frontmatter.banner
+  const keywords = mdx.frontmatter.keywords
+  const path = mdx.fields.path
+
+  // Build canonical URL
+  const canonicalUrl = `https://www.chrisvogt.me${path}`
 
   return (
     <Layout>
       <Themed.div sx={{ py: 3 }}>
         <Container sx={{ position: 'relative', width: ['', '', 'max(80ch, 50vw)'], lineHeight: 1.7 }}>
-          <article className='h-entry c1v0-blog-post'>
+          <article className='h-entry c1v0-blog-post' id={mdx.id}>
             {category && <Category type={category} sx={{ mb: 2 }} />}
 
             <PageHeader>{title}</PageHeader>
@@ -33,6 +40,21 @@ const PostTemplate = ({ children, data }) => {
             >
               <time className='dt-published created'>Published {date}</time>
             </Themed.div>
+
+            {/* Hidden microformats data */}
+            <div style={{ display: 'none' }}>
+              <a className='u-url' href={canonicalUrl} />
+              <span className='u-uid'>{mdx.id}</span>
+              {description && <div className='p-summary'>{description}</div>}
+              {banner && <img className='u-photo' src={banner} alt='' />}
+              {category && <span className='p-category'>{category}</span>}
+              {keywords &&
+                keywords.map((keyword, index) => (
+                  <span key={index} className='p-category'>
+                    {keyword}
+                  </span>
+                ))}
+            </div>
 
             <div className='e-content article-content'>{children}</div>
           </article>
@@ -54,13 +76,16 @@ export const pageQuery = graphql`
   query ($id: String!) {
     mdx(fields: { id: { eq: $id } }) {
       body
+      id
       fields {
         category
+        path
       }
       frontmatter {
         banner
         date(formatString: "MMMM DD, YYYY")
         description
+        keywords
         title
       }
     }

--- a/theme/src/templates/post.spec.js
+++ b/theme/src/templates/post.spec.js
@@ -6,14 +6,17 @@ import Post, { Head } from './post'
 
 const data = {
   mdx: {
+    id: 'mock-post-id',
     fields: {
-      category: 'Mock Category'
+      category: 'Mock Category',
+      path: '/blog/mock-post'
     },
     frontmatter: {
       date: 'Mon, 17 Jun 2024 03:30:26 GMT',
       title: 'A Mock Blog Post',
       description: 'This is a mock description',
-      banner: 'mock-banner.jpg'
+      banner: 'mock-banner.jpg',
+      keywords: ['mock', 'test', 'blog']
     }
   }
 }
@@ -49,6 +52,7 @@ describe('Blog Post', () => {
       mdx: {
         ...data.mdx,
         fields: {
+          ...data.mdx.fields,
           category: null
         }
       }


### PR DESCRIPTION
This PR adds [h-entry microformats markup](https://indieweb.org/h-entry) to the media and post templates, allowing my site to be consumed by indieweb readers, and I assume... AI scrapers?

## AI summary

This pull request enhances microformats support, improves metadata handling, and updates tests across multiple components. Key changes include adding hidden microformats data for better semantic web compatibility, expanding metadata fields in templates, and updating snapshot tests to reflect these improvements.

### Microformats Enhancements:
* Added hidden microformats data (`u-url`, `u-uid`, `p-summary`, `u-photo`, and `p-category`) to the `HCard` component and `MediaTemplate` and `PostTemplate` components to improve semantic web compatibility. (`theme/src/components/h-card.js`, `theme/src/templates/media.js`, `theme/src/templates/post.js`) [[1]](diffhunk://#diff-85dd12b2f489095f1fe4a22dbd801a7fee46c3bfb9f20db9e5eb550d89e221e4L5-R5) [[2]](diffhunk://#diff-85dd12b2f489095f1fe4a22dbd801a7fee46c3bfb9f20db9e5eb550d89e221e4R28) [[3]](diffhunk://#diff-7aec17c05fbff3a881e557f0b64adea6babcd094565d8b8db597f427cf1fce0aL61-R89) [[4]](diffhunk://#diff-7c64cdec505f2e400ce19b776212716279d128aa47a4bdc37a8e0c0599656c6bR44-R58)

### Metadata Improvements:
* Introduced new metadata fields (`id`, `path`, `keywords`, `description`, and `banner`) in `MediaTemplate` and `PostTemplate` components for enhanced SEO and structured data. (`theme/src/templates/media.js`, `theme/src/templates/post.js`) [[1]](diffhunk://#diff-7aec17c05fbff3a881e557f0b64adea6babcd094565d8b8db597f427cf1fce0aR27-R33) [[2]](diffhunk://#diff-7aec17c05fbff3a881e557f0b64adea6babcd094565d8b8db597f427cf1fce0aR110-R119) [[3]](diffhunk://#diff-7c64cdec505f2e400ce19b776212716279d128aa47a4bdc37a8e0c0599656c6bR17-R29) [[4]](diffhunk://#diff-7c64cdec505f2e400ce19b776212716279d128aa47a4bdc37a8e0c0599656c6bR79-R88)

### Snapshot Test Updates:
* Updated snapshot tests for `media.spec.js` and `post.spec.js` to include new metadata fields and hidden microformats data. (`theme/src/templates/__snapshots__/media.spec.js.snap`, `theme/src/templates/__snapshots__/post.spec.js.snap`) [[1]](diffhunk://#diff-1fd7aec5169417a58637ecbea18830fe896228bfd2f308a81f7c4c63ceac8532R15) [[2]](diffhunk://#diff-1fd7aec5169417a58637ecbea18830fe896228bfd2f308a81f7c4c63ceac8532R33-R79) [[3]](diffhunk://#diff-f5be4b25209277011c32dd8d08733d20b0ebcb1858a5458fb6a0fd9313d54917R15) [[4]](diffhunk://#diff-f5be4b25209277011c32dd8d08733d20b0ebcb1858a5458fb6a0fd9313d54917R32-R73)

### Test Data Adjustments:
* Modified mock data in `media.spec.js` and `post.spec.js` to include new metadata fields (`id`, `path`, `keywords`, `description`, and `banner`). (`theme/src/templates/media.spec.js`, `theme/src/templates/post.spec.js`) [[1]](diffhunk://#diff-6f6c728e3da7b4adc586cc18502fe3fa8e565b17fba6ec87f7f1b8e040d31787R13-R25) [[2]](diffhunk://#diff-4bae386c86bfef1578ead2479f6894378fc34829a62da19f8792209be5b64c41R9-R19)

### Documentation Update:
* Updated Jest snapshot version comment to point to the official Jest documentation link. (`theme/src/templates/__snapshots__/media.spec.js.snap`, `theme/src/templates/__snapshots__/post.spec.js.snap`) [[1]](diffhunk://#diff-1fd7aec5169417a58637ecbea18830fe896228bfd2f308a81f7c4c63ceac8532L1-R1) [[2]](diffhunk://#diff-f5be4b25209277011c32dd8d08733d20b0ebcb1858a5458fb6a0fd9313d54917L1-R1)