### PR TITLE
hotfix: busts cache for Flowers for Algernon

### DIFF
--- a/www.chrisvogt.me/gatsby-config.js
+++ b/www.chrisvogt.me/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
       },
       goodreads: {
         username: 'chrisvogt',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads'
+        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads?forceCacheReload=true'
       },
       instagram: {
         username: 'c1v0',


### PR DESCRIPTION
I find the API data returned for the _Flowers for Algernon_ book description rude and offensive. As a quick fix, I updated the data in the API and patched in new content. This adds a new query param to the data source URL to force the cache to bust on the client.