### PR TITLE
feat: adds support for HTML entities in book reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.46.0
+
+- Replaces Google Books API book descriptions with Goodreads book descriptions.
+- Adds support for `<i>`, `<b>`, and `<br />` elements in widget content response.
+
 ## 0.45.3
 
 – Rearranges the page header layout to accommodate longer menu items.

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.45.3",
+  "version": "0.46.0",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/goodreads/book-explorer.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.js
@@ -7,6 +7,7 @@ import { useLocation } from '@gatsbyjs/reach-router'
 
 import Book from '../../artwork/book'
 import ViewExternal from '../view-external'
+import { parseSafeHtml } from '../../../helpers/safeHtmlParser'
 
 const renderStarsForRating = count => {
   const repeat = (char, n) => Array(n).fill(char).join('')
@@ -114,7 +115,7 @@ const BookExplorer = ({ book, onClose }) => {
               <span sx={{ color: 'primary' }}>{renderStarsForRating(parseInt(rating, 10))}</span>
             </div>
 
-            <Themed.p sx={{ mt: 2, mb: 3 }}>{description}</Themed.p>
+            <Themed.p sx={{ mt: 2, mb: 3 }}>{parseSafeHtml(description)}</Themed.p>
 
             <Themed.a
               href={infoLink}

--- a/theme/src/components/widgets/goodreads/book-explorer.spec.js
+++ b/theme/src/components/widgets/goodreads/book-explorer.spec.js
@@ -93,4 +93,30 @@ describe('Widget/Goodreads/BookExplorer', () => {
     const link = screen.getByText('Learn more on Google Books')
     expect(link).not.toHaveAttribute('target')
   })
+
+  it('renders HTML entities in description correctly', () => {
+    const bookWithHtml = {
+      ...mockBook,
+      description: 'This is <b>bold</b> text with a <br /> line break and <i>italic</i> content'
+    }
+    renderWithRouter(<BookExplorer book={bookWithHtml} onClose={() => {}} default />)
+
+    // Check that the HTML is properly rendered as elements
+    const descriptionElement = screen.getByText(/This is/).closest('p')
+    expect(descriptionElement.innerHTML).toContain('<b>bold</b>')
+    expect(descriptionElement.innerHTML).toContain('<br>')
+    expect(descriptionElement.innerHTML).toContain('<i>italic</i>')
+    expect(descriptionElement.textContent).toBe('This is bold text with a  line break and italic content')
+  })
+
+  it('ignores unsupported HTML tags in description', () => {
+    const bookWithUnsupportedHtml = {
+      ...mockBook,
+      description: 'This has <div>unsupported</div> and <span>tags</span>'
+    }
+    renderWithRouter(<BookExplorer book={bookWithUnsupportedHtml} onClose={() => {}} default />)
+
+    // Should render the raw HTML as text
+    expect(screen.getByText('This has <div>unsupported</div> and <span>tags</span>')).toBeInTheDocument()
+  })
 })

--- a/theme/src/helpers/safeHtmlParser.js
+++ b/theme/src/helpers/safeHtmlParser.js
@@ -40,9 +40,18 @@ export const parseSafeHtml = text => {
 
 /**
  * Process inline tags (<b> and <i>) within a text segment
+ * Uses a simple approach that handles basic cases correctly
  */
 const processInlineTags = text => {
+  // Check if there are valid nested <b> or <i> tags (e.g., <b><i>text</i></b>)
+  const hasNestedTags = /<(b|i)>\s*<(b|i)>.*<\/(b|i)>\s*<\/(b|i)>/i.test(text)
+  if (hasNestedTags) {
+    const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    return <span dangerouslySetInnerHTML={{ __html: escaped }} />
+  }
+
   // Simple regex to match <b>content</b> and <i>content</i>
+  // This handles the basic cases without complex nesting
   const tagRegex = /<(b|i)>([^<]*)<\/\1>/gi
   const parts = []
   let lastIndex = 0

--- a/theme/src/helpers/safeHtmlParser.js
+++ b/theme/src/helpers/safeHtmlParser.js
@@ -1,0 +1,74 @@
+import React from 'react'
+
+/**
+ * Safely converts HTML entities to React elements
+ * Only supports: <b>, <i>, <br />
+ *
+ * @param {string} text - The text containing HTML entities
+ * @returns {React.ReactNode} - React elements or the original string
+ */
+export const parseSafeHtml = text => {
+  if (!text || typeof text !== 'string') {
+    return text
+  }
+
+  // Split by <br /> tags first
+  const parts = text.split(/<br\s*\/?>/i)
+
+  if (parts.length === 1) {
+    // No <br /> tags, just process <b> and <i>
+    return processInlineTags(parts[0])
+  }
+
+  // Process each part and join with <br /> elements
+  return parts.map((part, index) => {
+    const processedPart = processInlineTags(part)
+
+    if (index === parts.length - 1) {
+      // Last part doesn't need a <br />
+      return processedPart
+    }
+
+    return (
+      <React.Fragment key={index}>
+        {processedPart}
+        <br />
+      </React.Fragment>
+    )
+  })
+}
+
+/**
+ * Process inline tags (<b> and <i>) within a text segment
+ */
+const processInlineTags = text => {
+  // Simple regex to match <b>content</b> and <i>content</i>
+  const tagRegex = /<(b|i)>([^<]*)<\/\1>/gi
+  const parts = []
+  let lastIndex = 0
+  let match
+
+  while ((match = tagRegex.exec(text)) !== null) {
+    const [fullMatch, tag, content] = match
+
+    // Add text before the tag
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index))
+    }
+
+    // Create the element
+    const Element = tag === 'b' ? 'b' : 'i'
+    parts.push(React.createElement(Element, { key: `${tag}-${parts.length}` }, content))
+
+    lastIndex = match.index + fullMatch.length
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  return parts.length === 0 ? text : parts.length === 1 ? parts[0] : parts
+}
+
+export default parseSafeHtml

--- a/theme/src/helpers/safeHtmlParser.spec.js
+++ b/theme/src/helpers/safeHtmlParser.spec.js
@@ -1,0 +1,183 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { parseSafeHtml } from './safeHtmlParser'
+
+describe('parseSafeHtml', () => {
+  it('should return null/undefined as-is', () => {
+    expect(parseSafeHtml(null)).toBeNull()
+    expect(parseSafeHtml(undefined)).toBeUndefined()
+  })
+
+  it('should return non-string values as-is', () => {
+    expect(parseSafeHtml(123)).toBe(123)
+    expect(parseSafeHtml({})).toEqual({})
+    expect(parseSafeHtml([])).toEqual([])
+  })
+
+  it('should return empty string as-is', () => {
+    expect(parseSafeHtml('')).toBe('')
+  })
+
+  it('should return plain text without HTML as-is', () => {
+    const text = 'This is plain text without any HTML tags'
+    expect(parseSafeHtml(text)).toBe(text)
+  })
+
+  it('should handle <b> tags correctly', () => {
+    const text = 'This is <b>bold</b> text'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<b>bold</b>')
+    expect(container.textContent).toBe('This is bold text')
+  })
+
+  it('should handle <i> tags correctly', () => {
+    const text = 'This is <i>italic</i> text'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<i>italic</i>')
+    expect(container.textContent).toBe('This is italic text')
+  })
+
+  it('should handle multiple <b> and <i> tags', () => {
+    const text = 'This is <b>bold</b> and <i>italic</i> text'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<b>bold</b>')
+    expect(container.innerHTML).toContain('<i>italic</i>')
+    expect(container.textContent).toBe('This is bold and italic text')
+  })
+
+  it('should not support nested tags', () => {
+    const text = 'This is <b><i>bold italic</i></b> text'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    // Nested tags are not processed, returned as-is
+    expect(container.innerHTML).toContain('&lt;b&gt;&lt;i&gt;bold italic&lt;/i&gt;&lt;/b&gt;')
+    expect(container.textContent).toBe('This is <b><i>bold italic</i></b> text')
+  })
+
+  it('should handle <br /> tags correctly', () => {
+    const text = 'Line 1<br />Line 2'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<br>')
+    expect(container.textContent).toBe('Line 1Line 2')
+  })
+
+  it('should handle <br> tags without slash', () => {
+    const text = 'Line 1<br>Line 2'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<br>')
+    expect(container.textContent).toBe('Line 1Line 2')
+  })
+
+  it('should handle multiple <br /> tags', () => {
+    const text = 'Line 1<br />Line 2<br />Line 3'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    const brElements = container.querySelectorAll('br')
+    expect(brElements).toHaveLength(2)
+    expect(container.textContent).toBe('Line 1Line 2Line 3')
+  })
+
+  it('should handle mixed tags with <br />', () => {
+    const text = 'This is <b>bold</b><br />and <i>italic</i>'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<b>bold</b>')
+    expect(container.innerHTML).toContain('<br>')
+    expect(container.innerHTML).toContain('<i>italic</i>')
+    expect(container.textContent).toBe('This is boldand italic')
+  })
+
+  it('should ignore unsupported HTML tags', () => {
+    const text = 'This is <div>div content</div> and <span>span content</span>'
+    const result = parseSafeHtml(text)
+    expect(result).toBe(text) // Should return original text unchanged
+  })
+
+  it('should not parse malformed HTML', () => {
+    const text = 'This is <b>unclosed bold and <i>italic</b>'
+    const result = parseSafeHtml(text)
+    // Malformed HTML is ignored, returned as-is
+    expect(result).toBe(text)
+  })
+
+  it('should parse case-insensitive tags', () => {
+    const text = 'This is <B>BOLD</B> and <I>ITALIC</I>'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<i>BOLD</i>')
+    expect(container.innerHTML).toContain('<i>ITALIC</i>')
+    expect(container.textContent).toBe('This is BOLD and ITALIC')
+  })
+
+  it('should handle case-insensitive <br /> tags', () => {
+    const text = 'Line 1<BR />Line 2<Br>Line 3'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    const brElements = container.querySelectorAll('br')
+    expect(brElements).toHaveLength(2)
+    expect(container.textContent).toBe('Line 1Line 2Line 3')
+  })
+
+  it('should handle empty tag content', () => {
+    const text = 'This is <b></b> empty'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<b></b>')
+    expect(container.textContent).toBe('This is  empty')
+  })
+
+  it('should handle text with only <br /> tags', () => {
+    const text = '<br /><br />'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    const brElements = container.querySelectorAll('br')
+    expect(brElements).toHaveLength(2)
+    expect(container.textContent).toBe('')
+  })
+
+  it('should handle text starting with <br />', () => {
+    const text = '<br />Line 2'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<br>')
+    expect(container.textContent).toBe('Line 2')
+  })
+
+  it('should handle text ending with <br />', () => {
+    const text = 'Line 1<br />'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<br>')
+    expect(container.textContent).toBe('Line 1')
+  })
+
+  it('should handle text with only inline tags', () => {
+    const text = '<b>Bold</b><i>Italic</i>'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<b>Bold</b>')
+    expect(container.innerHTML).toContain('<i>Italic</i>')
+    expect(container.textContent).toBe('BoldItalic')
+  })
+
+  it('should handle text with only one tag', () => {
+    const text = '<b>Bold</b>'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<b>Bold</b>')
+    expect(container.textContent).toBe('Bold')
+  })
+
+  it('should handle text with only one <br /> tag', () => {
+    const text = '<br />'
+    const result = parseSafeHtml(text)
+    const { container } = render(<div>{result}</div>)
+    expect(container.innerHTML).toContain('<br>')
+    expect(container.textContent).toBe('')
+  })
+})

--- a/www.chrisvogt.me/gatsby-config.js
+++ b/www.chrisvogt.me/gatsby-config.js
@@ -40,7 +40,7 @@ module.exports = {
       },
       goodreads: {
         username: 'chrisvogt',
-        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads?forceCacheReload=true'
+        widgetDataSource: 'https://metrics.chrisvogt.me/api/widgets/goodreads?cacheBustVersion=2'
       },
       instagram: {
         username: 'c1v0',

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
This PR extends #359 by adding support for `<b>`, `<i>`, and `<br />` HTML entities in book reviews. I'm doing this to prepare for chrisvogt/metrics#73, which will switch reviews back to Goodreads data from Google Books API data—which I'm doing because the Google Books API is returning unexpected, unwanted text in descriptions for some books. The Goodreads book description is consistently higher quality than Google Books.

## Screenshots

| Before | After |
|--------|-------|
|    <img width="1670" alt="book-before" src="https://github.com/user-attachments/assets/ba408381-c8fb-4762-8e1f-bb68003ac14f" />    |    <img width="1670" alt="book-after" src="https://github.com/user-attachments/assets/829f7c44-1446-4417-ad0e-7fe2289fa852" />   |

## AI summary

This pull request introduces a new helper function for safely parsing HTML content and updates the Goodreads Book Explorer widget to use it. Additionally, it includes a minor configuration change for the Goodreads widget data source. Below are the key changes grouped by theme:

### Enhancements to HTML Parsing:

* Added a new helper function, `parseSafeHtml`, in `theme/src/helpers/safeHtmlParser.js` to safely convert HTML entities (supporting `<b>`, `<i>`, and `<br />` tags) into React elements or plain text. This ensures safe rendering of user-provided HTML content.

### Updates to Goodreads Book Explorer Widget:

* Updated the `BookExplorer` component in `theme/src/components/widgets/goodreads/book-explorer.js` to use the new `parseSafeHtml` function for rendering book descriptions, ensuring that HTML content is safely processed before display.
* Imported the `parseSafeHtml` helper function into the `BookExplorer` component file.

### Configuration Adjustments:

* Modified the `widgetDataSource` URL for the Goodreads widget in `www.chrisvogt.me/gatsby-config.js` to include a `cacheBustVersion` parameter for improved cache control.