### PR TITLE
fix: hour rounding in recently-played Steam table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.46.1
+
+- Fixes the recently-played Steam games table so that it reports down to the minute, instead of rounding hours up or down (_e.g._, "0 hours" played).
+
 ## 0.46.0
 
 - Replaces Google Books API book descriptions with Goodreads book descriptions.

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-theme-chrisvogt",
   "description": "My personal blog and website.",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "author": "Chris Vogt <mail@chrisvogt.me> (https://www.chrisvogt.me)",
   "main": "index.js",
   "license": "MIT",

--- a/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap
@@ -39,10 +39,10 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        17 hours
+        16 hours, 40 minutes
       </td>
       <td>
-        1 hour
+        50 minutes
       </td>
     </tr>
     <tr>
@@ -66,7 +66,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        18 hours
+        18 hours, 20 minutes
       </td>
       <td>
         <span
@@ -100,7 +100,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         20 hours
       </td>
       <td>
-        1 hour
+        1 hour, 10 minutes
       </td>
     </tr>
     <tr>
@@ -124,7 +124,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        22 hours
+        21 hours, 40 minutes
       </td>
       <td>
         <span
@@ -155,10 +155,10 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        23 hours
+        23 hours, 20 minutes
       </td>
       <td>
-        2 hours
+        1 hour, 30 minutes
       </td>
     </tr>
     <tr>
@@ -213,10 +213,10 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        27 hours
+        26 hours, 40 minutes
       </td>
       <td>
-        2 hours
+        1 hour, 50 minutes
       </td>
     </tr>
     <tr>
@@ -240,7 +240,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        28 hours
+        28 hours, 20 minutes
       </td>
       <td>
         <span
@@ -274,7 +274,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         30 hours
       </td>
       <td>
-        2 hours
+        2 hours, 10 minutes
       </td>
     </tr>
     <tr>
@@ -298,7 +298,7 @@ exports[`OwnedGamesTable renders correctly with exactly 11 games and shows singu
         </div>
       </td>
       <td>
-        32 hours
+        31 hours, 40 minutes
       </td>
       <td>
         <span
@@ -386,10 +386,10 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        17 hours
+        16 hours, 40 minutes
       </td>
       <td>
-        1 hour
+        50 minutes
       </td>
     </tr>
     <tr>
@@ -413,7 +413,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        18 hours
+        18 hours, 20 minutes
       </td>
       <td>
         <span
@@ -447,7 +447,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         20 hours
       </td>
       <td>
-        1 hour
+        1 hour, 10 minutes
       </td>
     </tr>
     <tr>
@@ -471,7 +471,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        22 hours
+        21 hours, 40 minutes
       </td>
       <td>
         <span
@@ -502,10 +502,10 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        23 hours
+        23 hours, 20 minutes
       </td>
       <td>
-        2 hours
+        1 hour, 30 minutes
       </td>
     </tr>
     <tr>
@@ -560,10 +560,10 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        27 hours
+        26 hours, 40 minutes
       </td>
       <td>
-        2 hours
+        1 hour, 50 minutes
       </td>
     </tr>
     <tr>
@@ -587,7 +587,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        28 hours
+        28 hours, 20 minutes
       </td>
       <td>
         <span
@@ -621,7 +621,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         30 hours
       </td>
       <td>
-        2 hours
+        2 hours, 10 minutes
       </td>
     </tr>
     <tr>
@@ -645,7 +645,7 @@ exports[`OwnedGamesTable renders correctly with exactly 12 games and shows plura
         </div>
       </td>
       <td>
-        32 hours
+        31 hours, 40 minutes
       </td>
       <td>
         <span
@@ -734,10 +734,10 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        17 hours
+        16 hours, 40 minutes
       </td>
       <td>
-        1 hour
+        50 minutes
       </td>
     </tr>
     <tr>
@@ -761,7 +761,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        18 hours
+        18 hours, 20 minutes
       </td>
       <td>
         <span
@@ -795,7 +795,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         20 hours
       </td>
       <td>
-        1 hour
+        1 hour, 10 minutes
       </td>
     </tr>
     <tr>
@@ -819,7 +819,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        22 hours
+        21 hours, 40 minutes
       </td>
       <td>
         <span
@@ -850,10 +850,10 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        23 hours
+        23 hours, 20 minutes
       </td>
       <td>
-        2 hours
+        1 hour, 30 minutes
       </td>
     </tr>
     <tr>
@@ -908,10 +908,10 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        27 hours
+        26 hours, 40 minutes
       </td>
       <td>
-        2 hours
+        1 hour, 50 minutes
       </td>
     </tr>
     <tr>
@@ -935,7 +935,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        28 hours
+        28 hours, 20 minutes
       </td>
       <td>
         <span
@@ -969,7 +969,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         30 hours
       </td>
       <td>
-        2 hours
+        2 hours, 10 minutes
       </td>
     </tr>
     <tr>
@@ -993,7 +993,7 @@ exports[`OwnedGamesTable renders correctly with more than 10 games and shows rem
         </div>
       </td>
       <td>
-        32 hours
+        31 hours, 40 minutes
       </td>
       <td>
         <span
@@ -1082,7 +1082,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
         </div>
       </td>
       <td>
-        757 hours
+        757 hours, 21 minutes
       </td>
       <td>
         2 hours
@@ -1109,7 +1109,7 @@ exports[`OwnedGamesTable renders correctly with sample data 1`] = `
         </div>
       </td>
       <td>
-        278 hours
+        277 hours, 50 minutes
       </td>
       <td>
         <span
@@ -1146,5 +1146,3 @@ exports[`OwnedGamesTable renders empty state when no games provided 1`] = `
   No owned games found.
 </p>
 `;
-
-exports[`TimeSpent renders humanized time correctly 1`] = `"0 hours"`;

--- a/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
+++ b/theme/src/components/widgets/steam/__snapshots__/steam-widget.spec.js.snap
@@ -116,5 +116,3 @@ exports[`SteamWidget renders loading state 1`] = `
   />
 </div>
 `;
-
-exports[`TimeSpent renders humanized time correctly 1`] = `"5 minutes"`;

--- a/theme/src/components/widgets/steam/get-time-spent.js
+++ b/theme/src/components/widgets/steam/get-time-spent.js
@@ -1,0 +1,5 @@
+import humanizeDuration from 'humanize-duration'
+
+const getTimeSpent = timeInMs => humanizeDuration(timeInMs, { units: ['h', 'm'], round: true })
+
+export default getTimeSpent

--- a/theme/src/components/widgets/steam/get-time-spent.spec.js
+++ b/theme/src/components/widgets/steam/get-time-spent.spec.js
@@ -1,0 +1,43 @@
+import getTimeSpent from './get-time-spent'
+
+describe('getTimeSpent', () => {
+  it('formats 5 minutes correctly', () => {
+    const result = getTimeSpent(5 * 60 * 1000)
+    expect(result).toBe('5 minutes')
+  })
+
+  it('formats 1 hour correctly', () => {
+    const result = getTimeSpent(60 * 60 * 1000)
+    expect(result).toBe('1 hour')
+  })
+
+  it('formats 2 hours correctly', () => {
+    const result = getTimeSpent(2 * 60 * 60 * 1000)
+    expect(result).toBe('2 hours')
+  })
+
+  it('formats 1 hour and 30 minutes correctly', () => {
+    const result = getTimeSpent(90 * 60 * 1000)
+    expect(result).toBe('1 hour, 30 minutes')
+  })
+
+  it('formats 757 hours and 21 minutes correctly', () => {
+    const result = getTimeSpent(757 * 60 * 60 * 1000 + 21 * 60 * 1000)
+    expect(result).toBe('757 hours, 21 minutes')
+  })
+
+  it('formats 0 milliseconds as 0 minutes', () => {
+    const result = getTimeSpent(0)
+    expect(result).toBe('0 minutes')
+  })
+
+  it('formats 30 seconds correctly', () => {
+    const result = getTimeSpent(30 * 1000)
+    expect(result).toBe('1 minute')
+  })
+
+  it('formats 1 minute correctly', () => {
+    const result = getTimeSpent(60 * 1000)
+    expect(result).toBe('1 minute')
+  })
+})

--- a/theme/src/components/widgets/steam/owned-games-table.js
+++ b/theme/src/components/widgets/steam/owned-games-table.js
@@ -1,14 +1,9 @@
 /** @jsx jsx */
 import { jsx, useColorMode } from 'theme-ui'
-import { Fragment } from 'react'
 import { Themed } from '@theme-ui/mdx'
-import humanizeDuration from 'humanize-duration'
 
+import getTimeSpent from './get-time-spent'
 import ViewExternal from '../view-external'
-
-export const TimeSpent = ({ timeInMs }) => (
-  <Fragment>{humanizeDuration(timeInMs, { units: ['h'], round: true })}</Fragment>
-)
 
 const OwnedGamesTable = ({ games = [] }) => {
   const [colorMode] = useColorMode()
@@ -65,12 +60,10 @@ const OwnedGamesTable = ({ games = [] }) => {
                 </a>
               </div>
             </td>
-            <td>
-              <TimeSpent timeInMs={game.playTimeForever * 60 * 1000} />
-            </td>
+            <td>{getTimeSpent(game.playTimeForever * 60 * 1000)}</td>
             <td>
               {game.playTime2Weeks ? (
-                <TimeSpent timeInMs={game.playTime2Weeks * 60 * 1000} />
+                getTimeSpent(game.playTime2Weeks * 60 * 1000)
               ) : (
                 <span sx={{ color: 'tableText', fontStyle: 'italic' }}>–</span>
               )}

--- a/theme/src/components/widgets/steam/owned-games-table.spec.js
+++ b/theme/src/components/widgets/steam/owned-games-table.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { ThemeUIProvider } from 'theme-ui'
 import theme from '../../../gatsby-plugin-theme-ui'
-import OwnedGamesTable, { TimeSpent } from './owned-games-table'
+import OwnedGamesTable from './owned-games-table'
 
 const renderWithColorMode = component => {
   return renderer.create(<ThemeUIProvider theme={theme}>{component}</ThemeUIProvider>)
@@ -92,13 +92,6 @@ describe('OwnedGamesTable', () => {
     }))
 
     const tree = renderWithColorMode(<OwnedGamesTable games={twelveGames} />).toJSON()
-    expect(tree).toMatchSnapshot()
-  })
-})
-
-describe('TimeSpent', () => {
-  it('renders humanized time correctly', () => {
-    const tree = renderer.create(<TimeSpent timeInMs={5 * 60 * 1000} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/theme/src/components/widgets/steam/steam-widget.js
+++ b/theme/src/components/widgets/steam/steam-widget.js
@@ -1,12 +1,11 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui'
 import { faSteam } from '@fortawesome/free-brands-svg-icons'
-import { Fragment, useEffect } from 'react'
+import { useEffect } from 'react'
 import { get } from 'lodash'
 import { Heading } from '@theme-ui/components'
 import { Themed } from '@theme-ui/mdx'
 import { useDispatch, useSelector } from 'react-redux'
-import humanizeDuration from 'humanize-duration'
 import React from 'react'
 
 import CallToAction from '../call-to-action'
@@ -19,11 +18,8 @@ import OwnedGamesTable from './owned-games-table'
 import { SUCCESS, FAILURE, getSteamWidget } from '../../../reducers/widgets'
 import fetchDataSource from '../../../actions/fetchDataSource'
 import { getSteamWidgetDataSource } from '../../../selectors/metadata'
+import getTimeSpent from './get-time-spent'
 import useSiteMetadata from '../../../hooks/use-site-metadata'
-
-export const TimeSpent = ({ timeInMs }) => (
-  <Fragment>{humanizeDuration(timeInMs, { units: ['h', 'm'], round: true })}</Fragment>
-)
 
 const EMPTY_ARRAY = []
 
@@ -96,7 +92,7 @@ const SteamWidget = React.memo(() => {
         {recentlyPlayedGames.map(game => (
           <PostCard
             banner={game.images?.header}
-            date={<TimeSpent timeInMs={game.playTime2Weeks * 60 * 1000} />}
+            date={getTimeSpent(game.playTime2Weeks * 60 * 1000)}
             key={game.id}
             link={`https://store.steampowered.com/app/${game.id}`}
             title={game.displayName}

--- a/theme/src/components/widgets/steam/steam-widget.spec.js
+++ b/theme/src/components/widgets/steam/steam-widget.spec.js
@@ -2,7 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { Provider } from 'react-redux'
 import configureStore from 'redux-mock-store'
-import SteamWidget, { TimeSpent } from './steam-widget'
+import SteamWidget from './steam-widget'
 
 // Mock child components to isolate the test
 jest.mock('../call-to-action', () => props => <div data-testid='CallToAction'>{props.title}</div>)
@@ -102,13 +102,6 @@ describe('SteamWidget', () => {
       )
       .toJSON()
 
-    expect(tree).toMatchSnapshot()
-  })
-})
-
-describe('TimeSpent', () => {
-  it('renders humanized time correctly', () => {
-    const tree = renderer.create(<TimeSpent timeInMs={5 * 60 * 1000} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
 })

--- a/www.chrisvogt.me/package.json
+++ b/www.chrisvogt.me/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "www.chrisvogt.me",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "GPL",
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
This PR fixes hours being rounded down in my recently-played games table, and refactors the component that generates that time into a helper util.

## Screenshots

| Before | After |
|--------|-------|
|   <img width="1470" alt="table-before" src="https://github.com/user-attachments/assets/f99cdf3c-199b-469f-8f1a-8be88a3736c5" />     |   <img width="1470" alt="table-after" src="https://github.com/user-attachments/assets/bd80c421-cf79-400d-afac-a569b4a59af2" />    |

## AI summary

This pull request refactors the time formatting logic in the Steam widget and updates related tests and snapshots. The key changes include replacing the `TimeSpent` component with a new `getTimeSpent` utility function and updating all references accordingly. Additionally, the snapshots were updated to reflect the new time formatting.

### Refactoring and Utility Function Addition:
* Introduced a new `getTimeSpent` utility function in `theme/src/components/widgets/steam/get-time-spent.js` to format durations using the `humanize-duration` library.
* Added comprehensive unit tests for `getTimeSpent` in `theme/src/components/widgets/steam/get-time-spent.spec.js`. These tests cover various time formatting scenarios.

### Updates to `OwnedGamesTable`:
* Replaced the `TimeSpent` component with the `getTimeSpent` function in `theme/src/components/widgets/steam/owned-games-table.js`. This simplifies the code by removing the `TimeSpent` component entirely. [[1]](diffhunk://#diff-3abde98fe1344b271a0f9e8d4da14e9472195fee3d73e35d44252205266e1bfbL3-L12) [[2]](diffhunk://#diff-3abde98fe1344b271a0f9e8d4da14e9472195fee3d73e35d44252205266e1bfbL68-R66)
* Removed the unused `humanize-duration` import and cleaned up the code in `theme/src/components/widgets/steam/owned-games-table.js`.

### Test and Snapshot Updates:
* Updated snapshots in `theme/src/components/widgets/steam/__snapshots__/owned-games-table.spec.js.snap` to reflect the new time formatting logic. For example, durations like "1 hour" are now displayed as "1 hour, 10 minutes" where applicable. [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL42-R45) [[2]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL389-R392) [[3]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL737-R740) [[4]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL1085-R1085)
* Removed references to the `TimeSpent` component from the test file `theme/src/components/widgets/steam/owned-games-table.spec.js`.

### Cleanup:
* Removed unused test cases for the `TimeSpent` component from snapshot files, as the component is no longer used. [[1]](diffhunk://#diff-e67045cbe5eacd4b1c28c6db18d6c9fb7341f6d99d76e376612ecab68003059eL1149-L1150) [[2]](diffhunk://#diff-c6c061143984a6df2b8057febc15c2ba1d96c488518b0c824ae8e2055c06fdf4L119-L120)