### PR TITLE
fix: aligns the ColorToggle element vertically across browsers

### DIFF
--- a/theme/src/components/__snapshots__/top-navigation.spec.js.snap
+++ b/theme/src/components/__snapshots__/top-navigation.spec.js.snap
@@ -21,7 +21,7 @@ exports[`TopNavigation matches the snapshot 1`] = `
         My Personal Blog & Portfolio
       </a>
       <div
-        className="css-aesx5h"
+        className="css-9cpsy"
       />
     </div>
     <div

--- a/theme/src/components/top-navigation.js
+++ b/theme/src/components/top-navigation.js
@@ -63,7 +63,7 @@ const TopNavigation = () => {
             {title}
           </Link>
 
-          <Themed.div sx={{ display: 'block', position: 'relative', top: '5px' }}>
+          <Themed.div sx={{ display: 'flex', alignItems: 'center' }}>
             <ColorToggle />
           </Themed.div>
         </Themed.div>


### PR DESCRIPTION
This PR fixes an alignment issue with the <ColorToggle /> element where I was using manual offsets to vertically center the toggle, and that wasn't working consistently across browsers. Instead, I'm using flexbox and the browser's layout engine instead to achieve consistent vertical centering.

## Screenshots

| Before | After |
|--------|-------|
|    <img width="1722" alt="before-toggle" src="https://github.com/user-attachments/assets/bb2fd7a6-2e56-4b3d-bc3a-478abf255e7b" />    |   <img width="1722" alt="after-toggle" src="https://github.com/user-attachments/assets/0e3cff68-86e2-41d1-b4f4-8e31977ea58b" />    |

## AI summary

This pull request updates the `TopNavigation` component to improve its layout and maintain consistency with the snapshot tests. The changes primarily involve modifying the CSS classes and styling of the component.

Styling updates to `TopNavigation`:

* Updated the CSS class name for a `div` element in the snapshot file `theme/src/components/__snapshots__/top-navigation.spec.js.snap` to reflect changes in the component's styling. (`[theme/src/components/__snapshots__/top-navigation.spec.js.snapL24-R24](diffhunk://#diff-018fd8c1bd691c7964d4ad430c71627f164b5d31e6501e8411a09058c85b4919L24-R24)`)
* Changed the styling of the `Themed.div` wrapping the `ColorToggle` component in `theme/src/components/top-navigation.js` to use `display: 'flex'` and `alignItems: 'center'` for better alignment. (`[theme/src/components/top-navigation.jsL66-R66](diffhunk://#diff-b7f4b2c25adaf90bd604b314d1e2c56d9c542931e923d5541e48b2c2daf3f359L66-R66)`)