### PR TITLE
fix: matches audio player panel to current theme

### DIFF
--- a/theme/gatsby-ssr.js
+++ b/theme/gatsby-ssr.js
@@ -12,8 +12,14 @@ export const onRenderBody = ({ setHtmlAttributes, setPreBodyComponents }) => {
           var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
           mode = prefersDark ? 'dark' : 'default';
         }
+        // Set both attributes to ensure compatibility
         document.documentElement.setAttribute('data-theme-ui-color-mode', mode);
-      } catch (e) {}
+        document.documentElement.setAttribute('data-theme', mode);
+        // Also set the class for additional compatibility
+        document.documentElement.classList.add('theme-ui-' + mode);
+      } catch (e) {
+        console.warn('Failed to set color mode:', e);
+      }
     })();
   `
 

--- a/theme/src/components/audio-player.js
+++ b/theme/src/components/audio-player.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { jsx } from 'theme-ui'
+import { jsx, useColorMode, useThemeUI } from 'theme-ui'
 import { useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { useDispatch } from 'react-redux'
@@ -11,6 +11,8 @@ const AudioPlayer = ({ soundcloudId, spotifyURL, isVisible, provider }) => {
   const containerRef = useRef(null)
   const widgetRef = useRef(null)
   const dispatch = useDispatch()
+  const [colorMode] = useColorMode()
+  const { theme } = useThemeUI()
 
   // Create portal container on mount
   useEffect(() => {
@@ -45,6 +47,43 @@ const AudioPlayer = ({ soundcloudId, spotifyURL, isVisible, provider }) => {
     return null
   }
 
+  // Define background colors for each mode
+  const getBackgroundColor = () => {
+    // Debug logging (only in development)
+    if (process.env.NODE_ENV === 'development') {
+      console.log('AudioPlayer colorMode:', colorMode)
+      console.log('AudioPlayer theme colors:', theme?.colors)
+      if (typeof document !== 'undefined') {
+        console.log('Document theme attributes:', {
+          'data-theme-ui-color-mode': document.documentElement.getAttribute('data-theme-ui-color-mode'),
+          'data-theme': document.documentElement.getAttribute('data-theme')
+        })
+      }
+    }
+
+    // Primary method: use Theme UI's useColorMode hook
+    if (colorMode === 'dark') {
+      return 'rgba(1, 1, 1, 0.30)'
+    }
+
+    // Fallback method: check document attribute
+    if (typeof document !== 'undefined') {
+      const docMode =
+        document.documentElement.getAttribute('data-theme-ui-color-mode') ||
+        document.documentElement.getAttribute('data-theme')
+      if (docMode === 'dark') {
+        return 'rgba(1, 1, 1, 0.30)'
+      }
+    }
+
+    // Fallback to theme colors if available
+    if (theme && theme.colors && theme.colors['panel-background']) {
+      return theme.colors['panel-background']
+    }
+
+    return 'rgba(255, 255, 255, 0.35)'
+  }
+
   if (!isVisible || !provider || !containerRef.current) return null
 
   return createPortal(
@@ -54,7 +93,7 @@ const AudioPlayer = ({ soundcloudId, spotifyURL, isVisible, provider }) => {
         bottom: 0,
         left: 0,
         right: 0,
-        background: 'panel-background',
+        background: [getBackgroundColor(), 'var(--theme-ui-colors-panel-background, rgba(255, 255, 255, 0.35))'],
         backdropFilter: 'blur(8px)',
         WebkitBackdropFilter: 'blur(8px)', // for Safari
         pt: 2,

--- a/theme/src/components/audio-player.spec.js
+++ b/theme/src/components/audio-player.spec.js
@@ -8,6 +8,22 @@ import AudioPlayer from '../components/audio-player'
 jest.mock('../shortcodes/soundcloud', () => jest.fn(() => <div>MockSoundCloud</div>))
 jest.mock('../shortcodes/spotify', () => jest.fn(() => <div>MockSpotify</div>))
 
+// Mock the useColorMode hook
+jest.mock('theme-ui', () => {
+  const original = jest.requireActual('theme-ui')
+  return {
+    ...original,
+    useColorMode: jest.fn().mockReturnValue(['default', () => {}]),
+    useThemeUI: jest.fn().mockReturnValue({
+      theme: {
+        colors: {
+          'panel-background': 'rgba(255, 255, 255, 0.35)'
+        }
+      }
+    })
+  }
+})
+
 const mockStore = configureStore([])
 
 describe('AudioPlayer', () => {
@@ -17,6 +33,8 @@ describe('AudioPlayer', () => {
     store = mockStore({})
     store.dispatch = jest.fn()
     document.body.innerHTML = ''
+    // Reset all mocks before each test
+    jest.clearAllMocks()
   })
 
   it('renders and cleans up the portal container', async () => {


### PR DESCRIPTION
This PR fixes an issue observed in production where the background color of the audio player panel remains fixed on the light theme—and doesn't update on theme changes.

## AI summary

This pull request enhances the theme's color mode compatibility and improves the `AudioPlayer` component by adding dynamic background color logic and corresponding test updates. Key changes include updates to ensure compatibility with multiple color mode attributes, dynamic background color computation in the `AudioPlayer`, and improvements to the test suite.

### Enhancements to color mode compatibility:
* Updated `gatsby-ssr.js` to set both `data-theme-ui-color-mode` and `data-theme` attributes and added a corresponding CSS class for better compatibility. Added a warning log for error handling.

### Improvements to `AudioPlayer` component:
* Added `useColorMode` and `useThemeUI` hooks to the `AudioPlayer` component to dynamically determine the background color based on the current color mode, document attributes, or theme configuration. [[1]](diffhunk://#diff-1655c8a88b44e61e3de967f14cc2ad1d51188ca3e5e55b7972b11043e7a256d9L2-R2) [[2]](diffhunk://#diff-1655c8a88b44e61e3de967f14cc2ad1d51188ca3e5e55b7972b11043e7a256d9R14-R15) [[3]](diffhunk://#diff-1655c8a88b44e61e3de967f14cc2ad1d51188ca3e5e55b7972b11043e7a256d9R50-R86)
* Updated the `AudioPlayer`'s background style to use the dynamically computed background color with a fallback to the theme's `panel-background` color.

### Test suite updates:
* Mocked `useColorMode` and `useThemeUI` in the `AudioPlayer` tests to simulate color mode and theme configurations.
* Added `jest.clearAllMocks()` in the test setup to ensure clean mock states before each test.